### PR TITLE
build: add native Arch Linux and standalone AppImage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Download the latest `.deb` or `.AppImage` from the [Releases](https://github.com
 # .deb
 sudo dpkg -i streambert_*.deb
 
+# Arch Linux (.pkg.tar.zst)
+sudo pacman -U streambert-*.pkg.tar.zst
+
 # .AppImage (you can also do it with Gearlever)
 chmod +x Streambert-x64.AppImage && ./Streambert-x64.AppImage
 ```
@@ -89,6 +92,20 @@ or
 ```bash
 npm run dist:linux
 ```
+or (for Arch Linux)
+```bash
+npm run dist:arch
+```
+or (for an AppImage only)
+```bash
+npm run dist:appimage
+# To run:
+chmod +x dist/Streambert-*.AppImage && ./dist/Streambert-*.AppImage
+```
+
+> [!IMPORTANT]
+> If you are building on Arch Linux and encounter a `libcrypt.so.1` error, install the compatibility library:
+> `sudo pacman -S libxcrypt-compat`
 
 ---
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ Media Files for Animes are scraped from AllManga.to (i stole this mechanic from 
 On first launch you'll be prompted to enter your TMDB API key. ([Guide on how to get one](tmdb-tutorial.md))
 It's saved locally, you only need to do this once.
 
-### Linux, Manual (.deb / .AppImage)
+### Linux, Manual (.deb / .AppImage / .pacman)
 
 Download the latest `.deb` or `.AppImage` from the [Releases](https://github.com/truelockmc/streambert/releases/latest) page.
 ```bash
 # .deb
 sudo dpkg -i streambert_*.deb
 
-# Arch Linux (.pkg.tar.zst)
-sudo pacman -U streambert-*.pkg.tar.zst
+# Arch Linux (.pacman)
+sudo pacman -U streambert-*.pacman
 
 # .AppImage (you can also do it with Gearlever)
 chmod +x Streambert-x64.AppImage && ./Streambert-x64.AppImage
@@ -99,13 +99,12 @@ npm run dist:arch
 or (for an AppImage only)
 ```bash
 npm run dist:appimage
-# To run:
-chmod +x dist/Streambert-*.AppImage && ./dist/Streambert-*.AppImage
 ```
 
 > [!IMPORTANT]
-> If you are building on Arch Linux and encounter a `libcrypt.so.1` error, install the compatibility library:
-> `sudo pacman -S libxcrypt-compat`
+> If you are building/installing on Arch Linux and encounter errors, you may need these libraries:
+> - **libcrypt.so.1 error:** `sudo pacman -S libxcrypt-compat`
+> - **http-parser dependency error:** `yay -S http-parser` (from AUR)
 
 ---
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "dev": "vite build --watch",
     "start": "vite build && electron .",
     "dist": "cross-env ELECTRON_DIST=1 vite build && npm run dist:linux && npm run dist:win && npm run dist:mac",
-    "dist:linux": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux deb AppImage --publish never",
+    "dist:linux": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux deb AppImage pacman --publish never",
+    "dist:arch": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux pacman --publish never",
+    "dist:appimage": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux AppImage --publish never",
     "dist:win": "cross-env ELECTRON_DIST=1 vite build && electron-builder --win --publish never",
     "dist:mac": "cross-env ELECTRON_DIST=1 vite build && electron-builder --mac --publish never"
   },
@@ -128,6 +130,12 @@
         },
         {
           "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "pacman",
           "arch": [
             "x64"
           ]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "vite build && electron .",
     "dist": "cross-env ELECTRON_DIST=1 vite build && npm run dist:linux && npm run dist:win && npm run dist:mac",
     "dist:linux": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux deb AppImage pacman --publish never",
+    "dist:deb": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux deb --publish never",
     "dist:arch": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux pacman --publish never",
     "dist:appimage": "cross-env ELECTRON_DIST=1 vite build && electron-builder --linux AppImage --publish never",
     "dist:win": "cross-env ELECTRON_DIST=1 vite build && electron-builder --win --publish never",


### PR DESCRIPTION
This PR improves the Linux distribution workflow by adding support for native Arch Linux packages and standalone AppImage builds. this enables to run desktop application for non ubuntu and window users.

Changes
- Build Configuration: Added pacman and AppImage to the linux target in package.json
- Updated README.md with installation commands for Arch Linux (pacman -U).
