### PR TITLE
Implemented keyboard navigation for episode selection

### DIFF
--- a/src/pages/TVPage.jsx
+++ b/src/pages/TVPage.jsx
@@ -371,6 +371,7 @@ export default function TVPage({
     item.season != null ? Number(item.season) : 1,
   );
   const [selectedEp, setSelectedEp] = useState(null);
+  const [focusedEpisodeIndex, setFocusedEpisodeIndex] = useState(-1);
   const [playing, setPlaying] = useState(false);
   const [loading, setLoading] = useState(true);
   const [loadingSeason, setLoadingSeason] = useState(false);
@@ -554,6 +555,7 @@ export default function TVPage({
     }
     setLoadingSeason(true);
     setSelectedEp(null);
+    setFocusedEpisodeIndex(-1);
     setPlaying(false);
     setSeasonData(null); // clear stale episodes immediately
     // AniList virtual seasons on a single-season show: always fetch TMDB S1.
@@ -1416,6 +1418,47 @@ export default function TVPage({
     ? !!watched?.[currentProgressKey]
     : false;
 
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      // Don't intercept if user is typing
+      const active = document.activeElement;
+      if (active && active.matches('input, textarea, [contenteditable="true"]')) return;
+      // Don't intercept if player is actively focused
+      if (playing) return;
+
+      const maxIndex = currentSeasonEpisodes.length - 1;
+      if (maxIndex < 0) return;
+
+      if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+        e.preventDefault();
+        setFocusedEpisodeIndex((prev) => {
+          const next = prev < maxIndex ? prev + 1 : prev;
+          document.getElementById(`ep-card-${next}`)?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          return next;
+        });
+      } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+        e.preventDefault();
+        setFocusedEpisodeIndex((prev) => {
+          const next = prev > 0 ? prev - 1 : prev === -1 ? 0 : 0;
+          document.getElementById(`ep-card-${next}`)?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          return next;
+        });
+      } else if (e.key === "Enter") {
+        if (focusedEpisodeIndex >= 0 && focusedEpisodeIndex <= maxIndex) {
+          e.preventDefault();
+          const ep = currentSeasonEpisodes[focusedEpisodeIndex];
+          const epUnreleased = ep.air_date ? new Date(ep.air_date) > _todayForEpisodes : false;
+          if (!restricted && !epUnreleased) {
+            playEpisode(ep);
+          }
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [currentSeasonEpisodes, focusedEpisodeIndex, playing, restricted, playEpisode]);
+
   return (
     <div className="fade-in">
       {loading && (
@@ -2076,11 +2119,13 @@ export default function TVPage({
             {!loadingSeason &&
               (seasonData?.episodes || episodeGroupCurrentEpisodes?.length) && (
                 <div className="episodes-grid">
-                  {currentSeasonEpisodes.map((ep) => {
+                  {currentSeasonEpisodes.map((ep, idx) => {
                     const pk = `tv_${item.id}_s${selectedSeason}e${ep.episode_number}`;
                     return (
                       <EpisodeCard
                         key={ep.episode_number}
+                        id={`ep-card-${idx}`}
+                        isFocused={focusedEpisodeIndex === idx}
                         ep={ep}
                         itemId={item.id}
                         selectedSeason={selectedSeason}
@@ -2195,6 +2240,8 @@ const EpisodeCard = memo(function EpisodeCard({
   onPlay,
   onContextMenu,
   onGoToDownloads,
+  isFocused,
+  id,
 }) {
   const pk = `tv_${itemId}_s${selectedSeason}e${ep.episode_number}`;
   const isPlaying = playing && selectedEpNumber === ep.episode_number;
@@ -2207,7 +2254,8 @@ const EpisodeCard = memo(function EpisodeCard({
 
   return (
     <div
-      className={`episode-card ${isPlaying ? "playing" : ""} ${epWatched ? "ep-watched" : ""} ${restricted ? "episode-card--restricted" : ""} ${epUnreleased ? "episode-card--unreleased" : ""}`}
+      id={id}
+      className={`episode-card ${isPlaying ? "playing" : ""} ${epWatched ? "ep-watched" : ""} ${restricted ? "episode-card--restricted" : ""} ${epUnreleased ? "episode-card--unreleased" : ""} ${isFocused ? "focused" : ""}`}
       onClick={() => (restricted || epUnreleased ? null : onPlay(ep))}
       onContextMenu={(e) => {
         e.preventDefault();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1122,9 +1122,15 @@ body.no-anim *::after {
     align-items: flex-start;
 }
 
-.episode-card:hover {
+.episode-card:hover,
+.episode-card.focused {
     border-color: var(--red);
     background: var(--surface3);
+}
+
+.episode-card.focused {
+    outline: 2px solid var(--red);
+    outline-offset: 2px;
 }
 
 .episode-card.playing {


### PR DESCRIPTION
Addresses #16

## Description
This PR introduces keyboard navigation to the episode selection list on `TVPage`. This greatly improves accessibility and ease of use, allowing users to rapidly navigate through seasons without needing a mouse.

## Changes
- **State Management**: Added `focusedEpisodeIndex` state to `TVPage` to track the currently focused episode card.
- **Event Listeners**: Implemented a `keydown` listener to handle `ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`, and `Enter` keys.
- **Visuals**: Added visual focus indicators (`.episode-card.focused`) to the episode cards in `global.css` to match the hover styling.
- **Interaction**: Ensured that pressing `Enter` on a focused episode triggers playback, provided the episode is released and unrestricted.