### PR TITLE
Fix security vulnerabilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,10 @@ const playerWcIds = new Set();
 let sessionsConfigured = false;
 
 function setupSession(playerSession, trailerSession) {
+  // Streaming sites set CSP and X-Frame-Options to block embedding. These headers
+  // are stripped only on the dedicated player/trailer sessions (never the main window)
+  // so webviews can load the content. Both sessions run with contextIsolation and
+  // nodeIntegration disabled for additional isolation.
   const stripHeaders = (details, callback) => {
     const headers = { ...details.responseHeaders };
     for (const key of Object.keys(headers)) {

--- a/src/ipc/allmanga.js
+++ b/src/ipc/allmanga.js
@@ -734,7 +734,6 @@ function getPlayerServer() {
               ]) {
                 if (proxyRes.headers[h]) passHeaders[h] = proxyRes.headers[h];
               }
-              passHeaders["Access-Control-Allow-Origin"] = "*";
               passHeaders["Cache-Control"] = "no-store";
               res.writeHead(proxyRes.statusCode, passHeaders);
               proxyRes.pipe(res);

--- a/src/ipc/downloads.js
+++ b/src/ipc/downloads.js
@@ -104,7 +104,9 @@ function killAllDownloads() {
 
 // ── Subtitle file downloader (used during run-download completion) ─────────────
 
-function downloadSubtitleFile(url, destPath) {
+const MAX_SUBTITLE_REDIRECTS = 5;
+
+function downloadSubtitleFile(url, destPath, redirectCount = 0) {
   return new Promise((resolve) => {
     try {
       const parsedUrl = new URL(url);
@@ -134,10 +136,15 @@ function downloadSubtitleFile(url, destPath) {
             res.statusCode < 400 &&
             res.headers.location
           ) {
+            if (redirectCount >= MAX_SUBTITLE_REDIRECTS) {
+              res.resume();
+              resolve(false);
+              return;
+            }
             const loc = res.headers.location.startsWith("http")
               ? res.headers.location
               : parsedUrl.origin + res.headers.location;
-            downloadSubtitleFile(loc, destPath).then(resolve);
+            downloadSubtitleFile(loc, destPath, redirectCount + 1).then(resolve);
             return;
           }
           if (res.statusCode !== 200) {
@@ -688,9 +695,12 @@ function register(getMainWindow) {
         activeProcs.delete(id);
       }
       if (filePath) {
-        try {
-          if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
-        } catch {}
+        // Only unlink if the path matches the recorded entry to prevent arbitrary deletion
+        if (dlEntry && dlEntry.filePath === filePath) {
+          try {
+            if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+          } catch {}
+        }
       }
       for (const sp of dlEntry?.subtitlePaths || []) {
         try {

--- a/src/ipc/storage.js
+++ b/src/ipc/storage.js
@@ -204,14 +204,17 @@ function register() {
       const backupDir = settings.path;
       if (!backupDir) return { ok: false, error: "No backup path set" };
 
-      fs.mkdirSync(backupDir, { recursive: true });
+      const resolvedBackupDir = path.resolve(backupDir);
+      fs.mkdirSync(resolvedBackupDir, { recursive: true });
 
       const timestamp = new Date()
         .toISOString()
         .replace(/[:.]/g, "-")
         .slice(0, 19);
       const filename = `streambert-backup-${timestamp}.json`;
-      const fullPath = path.join(backupDir, filename);
+      const fullPath = path.join(resolvedBackupDir, filename);
+      if (!fullPath.startsWith(resolvedBackupDir + path.sep))
+        return { ok: false, error: "Invalid backup path" };
       fs.writeFileSync(
         fullPath,
         JSON.stringify(
@@ -229,19 +232,19 @@ function register() {
 
       // Prune old backups
       const keepCount = Math.max(1, Number(settings.keepCount) || 5);
-      fs.readdirSync(backupDir)
+      fs.readdirSync(resolvedBackupDir)
         .filter(
           (f) => f.startsWith("streambert-backup-") && f.endsWith(".json"),
         )
         .map((f) => ({
           name: f,
-          mtime: fs.statSync(path.join(backupDir, f)).mtimeMs,
+          mtime: fs.statSync(path.join(resolvedBackupDir, f)).mtimeMs,
         }))
         .sort((a, b) => b.mtime - a.mtime)
         .slice(keepCount)
         .forEach(({ name }) => {
           try {
-            fs.unlinkSync(path.join(backupDir, name));
+            fs.unlinkSync(path.join(resolvedBackupDir, name));
           } catch {}
         });
 

--- a/src/pages/TVPage.jsx
+++ b/src/pages/TVPage.jsx
@@ -227,7 +227,7 @@ const INJECT_SKIP_CONTROLS = `
 (function() {
   if (window.__skipControlsInjected) return;
   var style = document.createElement('style');
-  style.innerHTML =
+  style.textContent =
     '*:focus, *:focus-visible {' +
     'outline: none !important;' +
     'box-shadow: none !important;' +
@@ -255,7 +255,14 @@ const INJECT_SKIP_CONTROLS = `
 
   function makeBtn(seconds, svg, label, side) {
     var btn = document.createElement('button');
-    btn.innerHTML = svg + '<span style="font-size:11px;font-family:system-ui,sans-serif">' + label + '</span>';
+    var svgWrap = document.createElement('span');
+    svgWrap.innerHTML = svg;
+    var span = document.createElement('span');
+    span.style.fontSize = '11px';
+    span.style.fontFamily = 'system-ui,sans-serif';
+    span.textContent = label;
+    btn.appendChild(svgWrap.firstChild || svgWrap);
+    btn.appendChild(span);
     btn.setAttribute('tabindex', '-1');
     btn.title = label;
     btn.style.cssText = [


### PR DESCRIPTION
- downloads: cap subtitle redirect chain at 5 hops to prevent unbounded recursion/DoS
- downloads: validate filePath against recorded download entry before unlinking to prevent arbitrary file deletion
- allmanga: remove unnecessary Access-Control-Allow-Origin wildcard from localhost proxy (same-origin requests don't need it)
- storage: resolve and bounds-check backup directory path to prevent path traversal on write/prune
- TVPage: replace style.innerHTML with style.textContent; use textContent for button label to avoid innerHTML with variable content
- index.js: document why CSP/X-Frame-Options are stripped on player sessions only