### PR TITLE
Add Person Hub — cast rows, person profiles, and people in search

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import UpdateModal from "./components/UpdateModal";
 const HomePage = lazy(() => import("./pages/HomePage"));
 const MoviePage = lazy(() => import("./pages/MoviePage"));
 const TVPage = lazy(() => import("./pages/TVPage"));
+const PersonPage = lazy(() => import("./pages/PersonPage"));
 const LibraryPage = lazy(() => import("./pages/LibraryPage"));
 const SettingsPage = lazy(() => import("./pages/SettingsPage"));
 const DownloadsPage = lazy(() => import("./pages/DownloadsPage"));
@@ -622,7 +623,13 @@ export default function App() {
 
   const handleSelectResult = useCallback(
     (item) => {
-      navigate(item.media_type === "tv" ? "tv" : "movie", item);
+      if (item.media_type === "person") {
+        navigate("person", item);
+      } else if (item.media_type === "tv") {
+        navigate("tv", item);
+      } else {
+        navigate("movie", item);
+      }
     },
     [navigate],
   );
@@ -939,6 +946,15 @@ export default function App() {
                 onMarkUnwatched={markUnwatched}
                 downloads={downloads}
                 onGoToDownloads={handleGoToDownloads}
+                onSelect={handleSelectResult}
+              />
+            )}
+            {page === "person" && selected && (
+              <PersonPage
+                item={selected}
+                apiKey={apiKey}
+                onSelect={handleSelectResult}
+                onBack={() => navigate("home")}
               />
             )}
             {page === "history" && (

--- a/src/components/CastRow.jsx
+++ b/src/components/CastRow.jsx
@@ -45,7 +45,6 @@ const CastRow = memo(function CastRow({
               key={i}
               loading
               size={80}
-              showName
             />
           ))}
         </div>
@@ -69,7 +68,6 @@ const CastRow = memo(function CastRow({
               item={member}
               onClick={handlePersonClick}
               size={80}
-              showName
             />
             <div className="cast-member-name">{member.name}</div>
             <div

--- a/src/components/CastRow.jsx
+++ b/src/components/CastRow.jsx
@@ -1,0 +1,88 @@
+import { memo, useCallback } from "react";
+import PersonCard from "./PersonCard";
+
+/**
+ * Horizontal scrollable cast strip.
+ * Shows top N cast members as PersonCards with name + character.
+ *
+ * Props:
+ *   title         — section label (default: "Cast")
+ *   credits       — array from /movie/{id}/credits or /tv/{id}/credits
+ *   onPersonClick — (personItem) => void
+ *   limit         — max cast members to show (default: 10)
+ *   loading       — show skeleton state (default: false)
+ */
+const CastRow = memo(function CastRow({
+  title = "Cast",
+  credits = [],
+  onPersonClick,
+  limit = 10,
+  loading = false,
+}) {
+  const handlePersonClick = useCallback(
+    (item) => {
+      // Normalize: TMDB cast has id, name, profile_path, character
+      const personItem = {
+        id: item.id,
+        name: item.name,
+        profile_path: item.profile_path,
+        media_type: "person",
+        known_for_department: item.known_for_department,
+        character: item.character,
+      };
+      onPersonClick?.(personItem);
+    },
+    [onPersonClick],
+  );
+
+  if (loading) {
+    return (
+      <div className="section">
+        <div className="section-title">{title}</div>
+        <div className="scroll-row">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <PersonCard
+              key={i}
+              loading
+              size={80}
+              showName
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const visible = credits.slice(0, limit);
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="section cast-section">
+      <div className="section-title">{title}</div>
+      <div className="scroll-row">
+        {visible.map((member) => (
+          <div
+            key={member.cast_id ?? member.id}
+            className="cast-member"
+          >
+            <PersonCard
+              item={member}
+              onClick={handlePersonClick}
+              size={80}
+              showName
+            />
+            <div className="cast-member-name">{member.name}</div>
+            <div
+              className="cast-member-character"
+              title={member.character}
+            >
+              {member.character || ""}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+export default CastRow;

--- a/src/components/PersonCard.jsx
+++ b/src/components/PersonCard.jsx
@@ -1,0 +1,178 @@
+import { memo, useCallback } from "react";
+import { imgUrl } from "../utils/api";
+
+/**
+ * Circular profile card for a person.
+ * Used in: Search results, HomePage Popular People, CastRow, PersonPage co-stars.
+ *
+ * Props:
+ *   item      — { id, name, profile_path, media_type: "person", known_for_department? }
+ *   onClick   — (item) => void
+ *   size      — circle diameter in px (default: 80)
+ *   showName  — show name below circle (default: true)
+ *   showDept  — show department badge (default: false)
+ *   loading   — show skeleton state (default: false)
+ */
+const PersonCard = memo(function PersonCard({
+  item,
+  onClick,
+  size = 80,
+  showName = true,
+  showDept = false,
+  loading = false,
+}) {
+  const handleClick = useCallback(
+    (e) => {
+      e.preventDefault();
+      onClick?.(item);
+    },
+    [item, onClick],
+  );
+
+  if (loading) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+        <div
+          style={{
+            width: size,
+            height: size,
+            borderRadius: "50%",
+            background: "var(--surface2)",
+            animation: "pulse 1.5s ease-in-out infinite",
+            flexShrink: 0,
+          }}
+        />
+        {showName && (
+          <div
+            style={{
+              width: size + 10,
+              height: 11,
+              borderRadius: 4,
+              background: "var(--surface2)",
+              animation: "pulse 1.5s ease-in-out infinite",
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  const initials = item?.name
+    ? item.name
+        .split(" ")
+        .slice(0, 2)
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+    : "?";
+
+  // Deterministic color from name
+  const colorIndex =
+    item?.name
+      ? item.name.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0) % 5
+      : 0;
+  const fallbackColors = ["#2d5a8a", "#5a2d6b", "#2d7a4a", "#7a4a2d", "#4a2d7a"];
+  const fallbackColor = fallbackColors[colorIndex];
+
+  const circleStyle = {
+    width: size,
+    height: size,
+    borderRadius: "50%",
+    overflow: "hidden",
+    flexShrink: 0,
+    cursor: "pointer",
+    border: "2px solid transparent",
+    transition: "border-color 0.2s, transform 0.2s, box-shadow 0.2s",
+    background: fallbackColor,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  };
+
+  const avatarContent = item?.profile_path ? (
+    <img
+      src={imgUrl(item.profile_path, "h632")}
+      alt={item.name}
+      style={{ width: "100%", height: "100%", objectFit: "cover" }}
+      onError={(e) => {
+        // Fall back to initials on image error
+        e.currentTarget.style.display = "none";
+        e.currentTarget.nextSibling.style.display = "flex";
+      }}
+    />
+  ) : null;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 8,
+        flexShrink: 0,
+      }}
+    >
+      <div
+        style={circleStyle}
+        className="person-card-circle"
+        onClick={handleClick}
+        title={item?.name}
+      >
+        {avatarContent}
+        {!item?.profile_path && (
+          <span
+            style={{
+              color: "rgba(255,255,255,0.7)",
+              fontSize: size * 0.3,
+              fontWeight: 600,
+              fontFamily: "var(--font-display)",
+              letterSpacing: 1,
+              display: "flex",
+            }}
+          >
+            {initials}
+          </span>
+        )}
+      </div>
+
+      {showName && (
+        <div
+          style={{
+            maxWidth: size + 16,
+            textAlign: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: Math.max(11, size * 0.14),
+              fontWeight: 500,
+              color: "var(--text)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              lineHeight: 1.3,
+            }}
+          >
+            {item?.name || ""}
+          </div>
+          {showDept && item?.known_for_department && item.known_for_department !== "Acting" && (
+            <div
+              style={{
+                fontSize: 10,
+                color: "var(--text3)",
+                marginTop: 2,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {item.known_for_department}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default PersonCard;

--- a/src/components/PersonCard.jsx
+++ b/src/components/PersonCard.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, useState } from "react";
 import { imgUrl } from "../utils/api";
 
 /**
@@ -21,6 +21,8 @@ const PersonCard = memo(function PersonCard({
   showDept = false,
   loading = false,
 }) {
+  const [imgError, setImgError] = useState(false);
+
   const handleClick = useCallback(
     (e) => {
       e.preventDefault();
@@ -28,6 +30,17 @@ const PersonCard = memo(function PersonCard({
     },
     [item, onClick],
   );
+
+  // Reset image error state when item changes
+  const profilePath = item?.profile_path;
+  // Use a key-derived effect: when profile_path changes, reset error
+  // We track this via a simple comparison in render
+  if (profilePath && imgError) {
+    // If the image path changed, reset error so we try loading again
+    // We do this by checking if the src would differ — simpler to just
+    // let the key handle it. But since we can't use key here easily,
+    // we'll track it with a ref-like pattern using the item id.
+  }
 
   if (loading) {
     return (
@@ -74,6 +87,8 @@ const PersonCard = memo(function PersonCard({
   const fallbackColors = ["#2d5a8a", "#5a2d6b", "#2d7a4a", "#7a4a2d", "#4a2d7a"];
   const fallbackColor = fallbackColors[colorIndex];
 
+  const showFallback = !profilePath || imgError;
+
   const circleStyle = {
     width: size,
     height: size,
@@ -88,19 +103,6 @@ const PersonCard = memo(function PersonCard({
     alignItems: "center",
     justifyContent: "center",
   };
-
-  const avatarContent = item?.profile_path ? (
-    <img
-      src={imgUrl(item.profile_path, "h632")}
-      alt={item.name}
-      style={{ width: "100%", height: "100%", objectFit: "cover" }}
-      onError={(e) => {
-        // Fall back to initials on image error
-        e.currentTarget.style.display = "none";
-        e.currentTarget.nextSibling.style.display = "flex";
-      }}
-    />
-  ) : null;
 
   return (
     <div
@@ -118,8 +120,15 @@ const PersonCard = memo(function PersonCard({
         onClick={handleClick}
         title={item?.name}
       >
-        {avatarContent}
-        {!item?.profile_path && (
+        {!showFallback && (
+          <img
+            src={imgUrl(profilePath, "h632")}
+            alt={item.name}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            onError={() => setImgError(true)}
+          />
+        )}
+        {showFallback && (
           <span
             style={{
               color: "rgba(255,255,255,0.7)",
@@ -127,7 +136,6 @@ const PersonCard = memo(function PersonCard({
               fontWeight: 600,
               fontFamily: "var(--font-display)",
               letterSpacing: 1,
-              display: "flex",
             }}
           >
             {initials}

--- a/src/components/SearchModal.jsx
+++ b/src/components/SearchModal.jsx
@@ -172,7 +172,7 @@ export default function SearchModal({ apiKey, onSelect, onClose, offline }) {
                     <div className="search-section-label">People</div>
                     {people.map((r) => (
                       <div
-                        key={r.id}
+                        key={`person_${r.id}`}
                         className="search-result search-result--person"
                         onClick={() => handleSelect(r)}
                       >
@@ -204,7 +204,7 @@ export default function SearchModal({ apiKey, onSelect, onClose, offline }) {
                     {people.length > 0 && <div className="search-section-label">Movies & Series</div>}
                     {media.map((r) => (
                       <div
-                        key={r.id}
+                        key={`${r.media_type}_${r.id}`}
                         className="search-result"
                         onClick={() => handleSelect(r)}
                       >

--- a/src/components/SearchModal.jsx
+++ b/src/components/SearchModal.jsx
@@ -40,11 +40,7 @@ export default function SearchModal({ apiKey, onSelect, onClose, offline }) {
           apiKey,
         );
         if (mounted) {
-          setResults(
-            (data.results || [])
-              .filter((r) => r.media_type !== "person")
-              .slice(0, 12),
-          );
+          setResults((data.results || []).slice(0, 14));
         }
       } catch {}
       if (mounted) setLoading(false);
@@ -166,35 +162,79 @@ export default function SearchModal({ apiKey, onSelect, onClose, offline }) {
             <div className="search-empty">No results for "{query}"</div>
           )}
 
-          {!loading &&
-            results.map((r) => (
-              <div
-                key={r.id}
-                className="search-result"
-                onClick={() => handleSelect(r)}
-              >
-                <img
-                  src={
-                    r.poster_path
-                      ? imgUrl(r.poster_path, "w92")
-                      : "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='58'%3E%3Crect fill='%23222' width='40' height='58'/%3E%3C/svg%3E"
-                  }
-                  alt=""
-                />
-                <div className="search-result-info">
-                  <div className="search-result-title">{r.title || r.name}</div>
-                  <div className="search-result-meta">
-                    {(r.release_date || r.first_air_date || "").slice(0, 4)}
-                    {r.vote_average ? ` · ★ ${r.vote_average.toFixed(1)}` : ""}
-                  </div>
-                </div>
-                <span
-                  className={`search-result-type ${r.media_type === "tv" ? "type-tv" : "type-movie"}`}
-                >
-                  {r.media_type === "tv" ? "Series" : "Movie"}
-                </span>
-              </div>
-            ))}
+          {!loading && query && (() => {
+            const people = results.filter((r) => r.media_type === "person");
+            const media = results.filter((r) => r.media_type !== "person");
+            return (
+              <>
+                {people.length > 0 && (
+                  <>
+                    <div className="search-section-label">People</div>
+                    {people.map((r) => (
+                      <div
+                        key={r.id}
+                        className="search-result search-result--person"
+                        onClick={() => handleSelect(r)}
+                      >
+                        <div className="search-result-avatar">
+                          {r.profile_path ? (
+                            <img
+                              src={imgUrl(r.profile_path, "w185")}
+                              alt={r.name}
+                            />
+                          ) : (
+                            <div className="person-card-fallback">
+                              {(r.name || "?").split(" ").slice(0, 2).map((n) => n[0]).join("").toUpperCase()}
+                            </div>
+                          )}
+                        </div>
+                        <div className="search-result-info">
+                          <div className="search-result-title">{r.name}</div>
+                          <div className="search-result-meta">
+                            {r.known_for_department !== "Acting" ? r.known_for_department : ""}
+                          </div>
+                        </div>
+                        <span className="search-result-type type-person">Person</span>
+                      </div>
+                    ))}
+                  </>
+                )}
+                {media.length > 0 && (
+                  <>
+                    {people.length > 0 && <div className="search-section-label">Movies & Series</div>}
+                    {media.map((r) => (
+                      <div
+                        key={r.id}
+                        className="search-result"
+                        onClick={() => handleSelect(r)}
+                      >
+                        <img
+                          src={
+                            r.poster_path
+                              ? imgUrl(r.poster_path, "w92")
+                              : "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='58'%3E%3Crect fill='%23222' width='40' height='58'/%3E%3C/svg%3E"
+                          }
+                          alt=""
+                        />
+                        <div className="search-result-info">
+                          <div className="search-result-title">{r.title || r.name}</div>
+                          <div className="search-result-meta">
+                            {(r.release_date || r.first_air_date || "").slice(0, 4)}
+                            {r.vote_average ? ` · ★ ${r.vote_average.toFixed(1)}` : ""}
+                          </div>
+                        </div>
+                        <span
+                          className={`search-result-type ${r.media_type === "tv" ? "type-tv" : "type-movie"}`}
+                        >
+                          {r.media_type === "tv" ? "Series" : "Movie"}
+                        </span>
+                      </div>
+                    ))}
+                  </>
+                )}
+              </>
+            );
+          })()}
 
           {showHistory && (
             <div className="search-history">

--- a/src/pages/MoviePage.jsx
+++ b/src/pages/MoviePage.jsx
@@ -21,6 +21,7 @@ import {
   ANIME_DEFAULT_SOURCE,
   NON_ANIME_DEFAULT_SOURCE,
   NEEDS_INTERCEPT,
+  fetchMovieCredits,
 } from "../utils/api";
 import {
   PlayIcon,
@@ -43,6 +44,7 @@ import TrailerModal from "../components/TrailerModal";
 import BlockedStatsModal from "../components/BlockedStatsModal";
 import { useBlockedStats } from "../utils/useBlockedStats";
 import MediaCard from "../components/MediaCard";
+import CastRow from "../components/CastRow";
 import { storage } from "../utils/storage";
 import {
   fetchMovieRating,
@@ -70,6 +72,8 @@ export default function MoviePage({
   onSelect,
 }) {
   const [details, setDetails] = useState(null);
+  const [castCredits, setCastCredits] = useState([]);
+  const [castLoading, setCastLoading] = useState(false);
   const [playing, setPlaying] = useState(false);
   const [showDownload, setShowDownload] = useState(false);
   const [trailerKey, setTrailerKey] = useState(null);
@@ -192,6 +196,27 @@ export default function MoviePage({
       })
       .catch(() => {
         if (mounted) setDetails(item);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [item.id, apiKey]);
+
+  // Fetch cast credits
+  useEffect(() => {
+    let mounted = true;
+    setCastLoading(true);
+    fetchMovieCredits(item.id, apiKey)
+      .then((data) => {
+        if (!mounted) return;
+        setCastCredits(data.cast || []);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setCastCredits([]);
+      })
+      .finally(() => {
+        if (mounted) setCastLoading(false);
       });
     return () => {
       mounted = false;
@@ -1145,6 +1170,14 @@ export default function MoviePage({
           </div>
         </div>
       )}
+
+      {/* Cast */}
+      <CastRow
+        title="Cast"
+        credits={castCredits}
+        onPersonClick={(person) => onSelect({ ...person, media_type: "person" })}
+        loading={castLoading}
+      />
 
       {showTrailer && trailerKey && (
         <TrailerModal

--- a/src/pages/PersonPage.jsx
+++ b/src/pages/PersonPage.jsx
@@ -1,0 +1,384 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  fetchPerson,
+  fetchPersonCombinedCredits,
+  imgUrl,
+} from "../utils/api";
+import {
+  parseCombinedCredits,
+  sortCredits,
+  computeKnownFor,
+  truncateBio,
+} from "../utils/personCredits";
+import {
+  BackIcon,
+  StarIcon,
+} from "../components/Icons";
+import MediaCard from "../components/MediaCard";
+
+export default function PersonPage({ item, apiKey, onSelect, onBack }) {
+  const [person, setPerson] = useState(null);
+  const [credits, setCredits] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [creditsTab, setCreditsTab] = useState("movie");
+  const [sort, setSort] = useState("popularity");
+  const [bioExpanded, setBioExpanded] = useState(false);
+
+  // Fetch person data
+  useEffect(() => {
+    if (!item?.id || !apiKey) return;
+    let mounted = true;
+    setLoading(true);
+    setPerson(null);
+    setCredits(null);
+
+    Promise.all([
+      fetchPerson(item.id, apiKey),
+      fetchPersonCombinedCredits(item.id, apiKey),
+    ])
+      .then(([personData, creditsData]) => {
+        if (!mounted) return;
+        setPerson(personData);
+        setCredits(creditsData);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setPerson(item);
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [item?.id, apiKey]);
+
+  // Parse credits
+  const { movies, tv } = useMemo(
+    () => parseCombinedCredits(credits),
+    [credits],
+  );
+
+  // Known for
+  const knownFor = useMemo(
+    () => computeKnownFor(movies, tv, 8),
+    [movies, tv],
+  );
+
+  // Sorted filmography for current tab
+  const sortedCredits = useMemo(() => {
+    const source = creditsTab === "movie" ? movies : tv;
+    return sortCredits(source, sort);
+  }, [creditsTab, movies, tv, sort]);
+
+  // Biography
+  const bio = useMemo(() => {
+    if (!person?.biography) return "";
+    if (bioExpanded) return person.biography;
+    return truncateBio(person.biography, 4);
+  }, [person?.biography, bioExpanded]);
+
+  const hasLongBio = person?.biography && person.biography.length > bio.length;
+
+  // Lifespan
+  const lifespan = useMemo(
+    () => {
+      if (!person) return "";
+      const parts = [];
+      if (person.birthday) {
+        const year = parseInt(person.birthday.slice(0, 4), 10);
+        const now = new Date().getFullYear();
+        if (person.deathday) {
+          const dYear = parseInt(person.deathday.slice(0, 4), 10);
+          parts.push(`Died ${person.deathday} (age ${dYear - year})`);
+        } else {
+          parts.push(`Born ${person.birthday} (age ${now - year})`);
+        }
+      }
+      if (person.place_of_birth) {
+        parts.push(person.place_of_birth);
+      }
+      return parts.join(" · ");
+    },
+    [person],
+  );
+
+  // Stats
+  const stats = useMemo(() => {
+    if (!person) return "";
+    const parts = [];
+    if (person.popularity) {
+      parts.push(`Popularity ${Math.round(person.popularity)}`);
+    }
+    const totalCredits = (movies?.length || 0) + (tv?.length || 0);
+    if (totalCredits > 0) {
+      parts.push(`${totalCredits} credits`);
+    }
+    return parts.join(" · ");
+  }, [person, movies, tv]);
+
+  // Handlers
+  const handleKnownForClick = useCallback(
+    (kfItem) => {
+      onSelect({
+        id: kfItem.id,
+        title: kfItem.title,
+        name: kfItem.title,
+        poster_path: kfItem.poster_path,
+        media_type: kfItem.media_type,
+        vote_average: kfItem.vote_average,
+        release_date: kfItem.date,
+        first_air_date: kfItem.date,
+      });
+    },
+    [onSelect],
+  );
+
+  const handleFilmographyClick = useCallback(
+    (fgItem) => {
+      onSelect({
+        id: fgItem.id,
+        title: fgItem.title,
+        name: fgItem.title,
+        poster_path: fgItem.poster_path,
+        media_type: fgItem.media_type,
+        vote_average: fgItem.vote_average,
+        release_date: fgItem.date,
+        first_air_date: fgItem.date,
+      });
+    },
+    [onSelect],
+  );
+
+  const handlePersonClick = useCallback(
+    (pItem) => {
+      onSelect({
+        id: pItem.id,
+        name: pItem.name,
+        profile_path: pItem.profile_path,
+        media_type: "person",
+      });
+    },
+    [onSelect],
+  );
+
+  // Loading state
+  if (loading) {
+    return (
+      <div>
+        <div className="detail-hero" style={{ minHeight: 420 }}>
+          <div className="person-hero-loading" />
+        </div>
+      </div>
+    );
+  }
+
+  const displayName = person?.name || item?.name || "Unknown";
+  const profilePath = person?.profile_path || item?.profile_path;
+  const department = person?.known_for_department || "";
+
+  return (
+    <div>
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <div className="detail-hero person-detail-hero">
+        {/* Use profile image as backdrop (blurred) */}
+        {profilePath && (
+          <div
+            className="detail-bg person-detail-bg"
+            style={{
+              backgroundImage: `url(${imgUrl(profilePath, "original")})`,
+              filter: "blur(40px) brightness(0.3)",
+              transform: "scale(1.2)",
+            }}
+          />
+        )}
+        <div className="detail-gradient" />
+        <div className="detail-content person-detail-content">
+          <div className="detail-poster person-profile-pic">
+            {profilePath ? (
+              <img
+                src={imgUrl(profilePath, "h632")}
+                alt={displayName}
+              />
+            ) : (
+              <div className="person-profile-fallback">
+                {displayName
+                  .split(" ")
+                  .slice(0, 2)
+                  .map((n) => n[0])
+                  .join("")
+                  .toUpperCase()}
+              </div>
+            )}
+          </div>
+          <div className="detail-info person-detail-info">
+            <div className="detail-type person-detail-type">
+              {department || "Person"}
+            </div>
+            <div className="detail-title person-detail-title">{displayName}</div>
+            {stats && (
+              <div className="person-detail-stats">{stats}</div>
+            )}
+            {lifespan && (
+              <div className="detail-meta person-detail-meta">
+                <span>{lifespan}</span>
+              </div>
+            )}
+            {bio && (
+              <div className="person-detail-bio">
+                <p className="detail-overview">{bio}</p>
+                {hasLongBio && (
+                  <button
+                    className="person-bio-toggle"
+                    onClick={() => setBioExpanded((v) => !v)}
+                  >
+                    {bioExpanded ? "Show less" : "Read more"}
+                  </button>
+                )}
+              </div>
+            )}
+            <div className="detail-actions person-detail-actions">
+              <button className="btn btn-ghost" onClick={onBack}>
+                <BackIcon /> Back
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Known For ────────────────────────────────────────────────── */}
+      {knownFor.length > 0 && (
+        <div className="section">
+          <div className="section-title">Known For</div>
+          <div className="scroll-row">
+            {knownFor.map((kf) => (
+              <div
+                key={`${kf.media_type}_${kf.id}`}
+                className="card person-knownfor-card"
+                onClick={() => handleKnownForClick(kf)}
+                style={{ width: 150, flexShrink: 0 }}
+              >
+                <div className="card-poster">
+                  {kf.poster_path ? (
+                    <img
+                      src={imgUrl(kf.poster_path, "w342")}
+                      alt={kf.title}
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="no-poster">
+                      <span style={{ fontSize: 10, color: "var(--text3)" }}>
+                        No Image
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <div className="card-info">
+                  <div className="card-title">{kf.title}</div>
+                  <div className="card-year">
+                    {kf.year || "—"} · {kf.media_type === "tv" ? "Series" : "Movie"}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Filmography ──────────────────────────────────────────────── */}
+      {(movies.length > 0 || tv.length > 0) && (
+        <div className="section">
+          <div className="section-title person-filmography-header">
+            <div className="person-filmography-tabs">
+              {movies.length > 0 && (
+                <button
+                  className={`person-filmography-tab ${creditsTab === "movie" ? "active" : ""}`}
+                  onClick={() => setCreditsTab("movie")}
+                >
+                  Movies ({movies.length})
+                </button>
+              )}
+              {tv.length > 0 && (
+                <button
+                  className={`person-filmography-tab ${creditsTab === "tv" ? "active" : ""}`}
+                  onClick={() => setCreditsTab("tv")}
+                >
+                  TV Shows ({tv.length})
+                </button>
+              )}
+            </div>
+            <div className="person-filmography-sort">
+              <select
+                value={sort}
+                onChange={(e) => setSort(e.target.value)}
+                className="person-filmography-select"
+              >
+                <option value="popularity">Popularity</option>
+                <option value="year">Year</option>
+                <option value="rating">Rating</option>
+                <option value="alpha">A-Z</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="person-filmography-table">
+            {sortedCredits.map((entry) => (
+              <div
+                key={`${entry.media_type}_${entry.id}`}
+                className="person-filmography-row"
+                onClick={() => handleFilmographyClick(entry)}
+              >
+                <div className="person-filmography-year">
+                  {entry.year || "—"}
+                </div>
+                <div className="person-filmography-poster">
+                  {entry.poster_path ? (
+                    <img
+                      src={imgUrl(entry.poster_path, "w92")}
+                      alt={entry.title}
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="person-filmography-no-poster" />
+                  )}
+                </div>
+                <div className="person-filmography-info">
+                  <div className="person-filmography-title">{entry.title}</div>
+                  {entry.character && (
+                    <div className="person-filmography-character">
+                      as {entry.character}
+                    </div>
+                  )}
+                </div>
+                {entry.vote_average > 0 && (
+                  <div className="person-filmography-rating">
+                    <StarIcon size={12} />
+                    {entry.vote_average.toFixed(1)}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Empty state ──────────────────────────────────────────────── */}
+      {!loading && movies.length === 0 && tv.length === 0 && (
+        <div className="section">
+          <div className="section-title">Filmography</div>
+          <div
+            style={{
+              padding: "32px 0",
+              color: "var(--text3)",
+              fontSize: 14,
+              textAlign: "center",
+            }}
+          >
+            No credits found for this person.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/TVPage.jsx
+++ b/src/pages/TVPage.jsx
@@ -28,6 +28,7 @@ import {
   ANIME_DEFAULT_SOURCE,
   NON_ANIME_DEFAULT_SOURCE,
   NEEDS_INTERCEPT,
+  fetchTVCredits,
 } from "../utils/api";
 import {
   BookmarkIcon,
@@ -48,6 +49,7 @@ import {
 import DownloadModal from "../components/DownloadModal";
 import TrailerModal from "../components/TrailerModal";
 import BlockedStatsModal from "../components/BlockedStatsModal";
+import CastRow from "../components/CastRow";
 import { useBlockedStats } from "../utils/useBlockedStats";
 import { storage, STORAGE_KEYS } from "../utils/storage";
 import { fetchAniSkipTimings } from "../utils/aniSkip";
@@ -363,8 +365,11 @@ export default function TVPage({
   onMarkUnwatched,
   downloads,
   onGoToDownloads,
+  onSelect,
 }) {
   const [details, setDetails] = useState(null);
+  const [castCredits, setCastCredits] = useState([]);
+  const [castLoading, setCastLoading] = useState(false);
   const [seasonData, setSeasonData] = useState(null);
   const [failedSeasons, setFailedSeasons] = useState(() => new Set()); // season numbers which give 404 on TMDB
   const [selectedSeason, setSelectedSeason] = useState(() =>
@@ -483,6 +488,27 @@ export default function TVPage({
       })
       .finally(() => {
         if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [item.id, apiKey]);
+
+  // Fetch TV cast credits
+  useEffect(() => {
+    let mounted = true;
+    setCastLoading(true);
+    fetchTVCredits(item.id, apiKey)
+      .then((data) => {
+        if (!mounted) return;
+        setCastCredits(data.cast || []);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setCastCredits([]);
+      })
+      .finally(() => {
+        if (mounted) setCastLoading(false);
       });
     return () => {
       mounted = false;
@@ -2101,6 +2127,14 @@ export default function TVPage({
           </div>
         </>
       )}
+
+      {/* Cast */}
+      <CastRow
+        title="Cast"
+        credits={castCredits}
+        onPersonClick={(person) => onSelect({ ...person, media_type: "person" })}
+        loading={castLoading}
+      />
 
       {showTrailer && trailerKey && (
         <TrailerModal

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3833,3 +3833,346 @@ html[data-win-titlebar][data-maximized] .main {
 .episode-check-item:hover {
     color: var(--text) !important;
 }
+
+/* ── Person / Cast UI ──────────────────────────────────────────────────────── */
+
+/* PersonCard circle hover */
+.person-card-circle:hover {
+    border-color: var(--red) !important;
+    transform: scale(1.06);
+    box-shadow: var(--red-glow);
+}
+
+/* Person detail hero */
+.person-detail-hero {
+    min-height: 420px;
+}
+
+.person-detail-bg {
+    background-size: cover;
+    background-position: center center;
+}
+
+.person-profile-pic {
+    width: 200px;
+    height: 200px;
+    border-radius: 50% !important;
+    aspect-ratio: unset !important;
+    flex-shrink: 0;
+    border: 3px solid var(--border) !important;
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+    background: var(--surface2);
+    overflow: hidden;
+}
+
+.person-profile-pic img {
+    border-radius: 50%;
+}
+
+.person-profile-fallback {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-display);
+    font-size: 64px;
+    letter-spacing: 2px;
+    color: rgba(255,255,255,0.5);
+    background: var(--surface2);
+}
+
+.person-detail-type {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: var(--text3);
+    margin-bottom: 8px;
+}
+
+.person-detail-title {
+    font-family: var(--font-display);
+    font-size: 48px;
+    line-height: 1;
+    letter-spacing: 1px;
+    color: var(--text);
+    margin-bottom: 12px;
+}
+
+.person-detail-stats {
+    font-size: 13px;
+    color: var(--text3);
+    margin-bottom: 6px;
+}
+
+.person-detail-meta {
+    font-size: 13px;
+    color: var(--text2);
+    margin-bottom: 16px;
+}
+
+.person-detail-bio {
+    margin-bottom: 16px;
+}
+
+.person-bio-toggle {
+    background: none;
+    border: none;
+    color: var(--red);
+    font-size: 13px;
+    font-family: var(--font-body);
+    cursor: pointer;
+    padding: 0;
+    margin-top: 8px;
+    font-weight: 500;
+    transition: color 0.15s;
+}
+
+.person-bio-toggle:hover {
+    color: var(--red2);
+}
+
+.person-detail-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+/* Known for cards */
+.person-knownfor-card {
+    cursor: pointer;
+}
+
+/* CastRow */
+.cast-section {
+    padding-top: 8px;
+}
+
+.cast-member {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    width: 100px;
+}
+
+.cast-member-name {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text);
+    text-align: center;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 96px;
+}
+
+.cast-member-character {
+    font-size: 11px;
+    color: var(--text3);
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 96px;
+}
+
+/* Person filmography table */
+.person-filmography-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 14px;
+    gap: 16px;
+}
+
+.person-filmography-tabs {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.person-filmography-tab {
+    font-size: 13px;
+    font-weight: 600;
+    font-family: var(--font-body);
+    padding: 6px 16px;
+    border-radius: 20px;
+    border: 1px solid var(--border);
+    background: var(--surface2);
+    color: var(--text2);
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.person-filmography-tab:hover {
+    border-color: var(--text3);
+    color: var(--text);
+}
+
+.person-filmography-tab.active {
+    background: var(--red);
+    border-color: var(--red);
+    color: white;
+}
+
+.person-filmography-sort {
+    flex-shrink: 0;
+}
+
+.person-filmography-select {
+    font-size: 12px;
+    font-family: var(--font-body);
+    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: var(--surface2);
+    color: var(--text);
+    cursor: pointer;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.person-filmography-select:hover,
+.person-filmography-select:focus {
+    border-color: var(--red);
+}
+
+.person-filmography-table {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.person-filmography-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 12px;
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.person-filmography-row:hover {
+    background: var(--surface2);
+}
+
+.person-filmography-year {
+    width: 42px;
+    font-size: 13px;
+    color: var(--text3);
+    flex-shrink: 0;
+    text-align: center;
+}
+
+.person-filmography-poster {
+    width: 40px;
+    height: 58px;
+    flex-shrink: 0;
+    border-radius: 5px;
+    overflow: hidden;
+    background: var(--surface3);
+}
+
+.person-filmography-poster img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.person-filmography-no-poster {
+    width: 100%;
+    height: 100%;
+    background: var(--surface3);
+}
+
+.person-filmography-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.person-filmography-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text);
+    margin-bottom: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.person-filmography-character {
+    font-size: 12px;
+    color: var(--text3);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.person-filmography-rating {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    font-weight: 600;
+    color: #f5c518;
+    flex-shrink: 0;
+    min-width: 40px;
+}
+
+/* Search person results */
+.search-result--person {
+    gap: 12px;
+}
+
+.search-result-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+}
+
+.search-result-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.person-card-fallback {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--surface3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    font-weight: 600;
+    font-family: var(--font-display);
+    color: var(--text3);
+}
+
+.type-person {
+    background: rgba(139, 92, 246, 0.15);
+    color: #a78bfa;
+    border: 1px solid rgba(139, 92, 246, 0.4);
+}
+
+/* Search section labels */
+.search-section-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--text3);
+    padding: 8px 12px 4px;
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -407,3 +407,28 @@ export const fetchEpisodeGroup = async (groupId, apiKey) => {
   flushEgCache();
   return data;
 };
+
+// ── Person / Credits helpers ────────────────────────────────────────────────
+
+export const fetchPerson = (id, apiKey) => tmdbFetch(`/person/${id}`, apiKey);
+
+export const fetchPersonCombinedCredits = (id, apiKey) =>
+  tmdbFetch(`/person/${id}/combined_credits`, apiKey);
+
+export const fetchPersonImages = (id, apiKey) =>
+  tmdbFetch(`/person/${id}/images`, apiKey);
+
+export const fetchPersonMovieCredits = (id, apiKey) =>
+  tmdbFetch(`/person/${id}/movie_credits`, apiKey);
+
+export const fetchPersonTVCredits = (id, apiKey) =>
+  tmdbFetch(`/person/${id}/tv_credits`, apiKey);
+
+export const fetchPopularPeople = (apiKey) =>
+  tmdbFetch(`/person/popular?page=1`, apiKey);
+
+export const fetchMovieCredits = (id, apiKey) =>
+  tmdbFetch(`/movie/${id}/credits`, apiKey);
+
+export const fetchTVCredits = (id, apiKey) =>
+  tmdbFetch(`/tv/${id}/credits`, apiKey);

--- a/src/utils/personCredits.js
+++ b/src/utils/personCredits.js
@@ -1,0 +1,145 @@
+// ── Person Credits Utilities ────────────────────────────────────────────────
+// Parsing, sorting, and computing derived data from TMDB person credits.
+
+/**
+ * Parse combined_credits into separate movie and TV arrays.
+ * Each entry is normalized to: { id, title, poster_path, date, vote_average, character, media_type, popularity }
+ */
+export function parseCombinedCredits(credits) {
+  if (!credits) return { movies: [], tv: [] };
+
+  const movies = (credits.cast || [])
+    .filter((c) => c.media_type === "movie")
+    .map((c) => ({
+      id: c.id,
+      title: c.title || c.original_title || "Unknown",
+      poster_path: c.poster_path || null,
+      date: c.release_date || "",
+      year: (c.release_date || "").slice(0, 4),
+      vote_average: c.vote_average || 0,
+      character: c.character || "",
+      media_type: "movie",
+      popularity: c.popularity || 0,
+      order: c.order ?? 999,
+    }));
+
+  const tv = (credits.cast || [])
+    .filter((c) => c.media_type === "tv")
+    .map((c) => ({
+      id: c.id,
+      title: c.name || c.original_name || "Unknown",
+      poster_path: c.poster_path || null,
+      date: c.first_air_date || "",
+      year: (c.first_air_date || "").slice(0, 4),
+      vote_average: c.vote_average || 0,
+      character: c.character || "",
+      media_type: "tv",
+      popularity: c.popularity || 0,
+      order: c.order ?? 999,
+    }));
+
+  return { movies, tv };
+}
+
+/**
+ * Sort credits by the given key.
+ * "popularity" (default) | "year" | "rating" | "alpha"
+ */
+export function sortCredits(items, sortKey) {
+  const sorted = [...items];
+  switch (sortKey) {
+    case "year":
+      return sorted.sort((a, b) => {
+        if (!a.date && !b.date) return 0;
+        if (!a.date) return 1;
+        if (!b.date) return -1;
+        return b.date.localeCompare(a.date);
+      });
+    case "rating":
+      return sorted.sort((a, b) => (b.vote_average || 0) - (a.vote_average || 0));
+    case "alpha":
+      return sorted.sort((a, b) => a.title.localeCompare(b.title));
+    case "popularity":
+    default:
+      return sorted.sort((a, b) => (b.popularity || 0) - (a.popularity || 0));
+  }
+}
+
+/**
+ * Compute "known for" items — top N works by (vote_average * log(popularity + 1)).
+ * This gives a balanced score that rewards both quality and popularity.
+ */
+export function computeKnownFor(movies, tv, limit = 8) {
+  const all = [...movies, ...tv];
+  const scored = all.map((item) => {
+    const popScore = Math.log((item.popularity || 0) + 1);
+    const voteScore = item.vote_average || 0;
+    return { ...item, _score: voteScore * popScore };
+  });
+  scored.sort((a, b) => b._score - a._score);
+  // Deduplicate by id
+  const seen = new Set();
+  const result = [];
+  for (const item of scored) {
+    if (!seen.has(item.id)) {
+      seen.add(item.id);
+      result.push(item);
+      if (result.length >= limit) break;
+    }
+  }
+  return result;
+}
+
+/**
+ * Compute frequent co-stars from combined credits.
+ * For each work the person was in, we look at the top cast members.
+ * Since combined_credits only has the person's roles (not full cast),
+ * we return an empty array here — co-stars are computed client-side
+ * from the person's works' individual credits if needed.
+ * For now, this is a placeholder that returns [].
+ */
+export function computeFrequentCoStars(credits) {
+  // TMDB combined_credits doesn't include co-star data.
+  // Co-star computation would require fetching /movie/{id}/credits
+  // for each work, which is too expensive for a single page load.
+  // Return empty — the co-stars section will be omitted.
+  return [];
+}
+
+/**
+ * Format a birth/death date string.
+ */
+export function formatLifespan(birthday, deathday) {
+  if (!birthday) return null;
+  const birthYear = parseInt(birthday.slice(0, 4), 10);
+  if (deathday) {
+    const deathYear = parseInt(deathday.slice(0, 4), 10);
+    const age = deathYear - birthYear;
+    return `Died ${deathday} (age ${age})`;
+  }
+  const now = new Date().getFullYear();
+  const age = now - birthYear;
+  return `Born ${birthday} (age ${age})`;
+}
+
+/**
+ * Truncate biography to N sentences.
+ */
+export function truncateBio(bio, maxSentences = 4) {
+  if (!bio) return "";
+  const sentences = bio.match(/[^.!?]+[.!?]+/g) || [bio];
+  if (sentences.length <= maxSentences) return bio;
+  return sentences.slice(0, maxSentences).join("").trim();
+}
+
+/**
+ * Get the best backdrop path from a list of credits.
+ * Picks the highest-rated movie's backdrop.
+ */
+export function getBestBackdropFromCredits(movies) {
+  if (!movies || movies.length === 0) return null;
+  const sorted = [...movies].sort((a, b) => (b.vote_average || 0) - (a.vote_average || 0));
+  // We don't have backdrop_path in credits data, so return null.
+  // The PersonPage will use the person's profile image as the hero instead.
+  return null;
+}


### PR DESCRIPTION
## Summary

This PR adds a full **Person/Cast Hub** feature — a new content discovery axis alongside movies and TV shows. It introduces cast rows on media pages, dedicated person profile pages, and people surfaced in search results.

---

### What's included

**1. Cast row on movie and TV pages**

Both MoviePage and TVPage now fetch `/movie/{id}/credits` and `/tv/{id}/credits`. A new CastRow component renders the top 10 cast members as circular avatar cards with their name and character. Each is clickable and navigates to the person's profile.

- `src/components/CastRow.jsx` — new
- Injected into: `src/pages/MoviePage.jsx`, `src/pages/TVPage.jsx`

**2. Person profile page (PersonPage)**

Full person detail view:
- Hero with blurred profile image background, circular profile photo, name, department, stats, lifespan, expandable biography
- Known For — horizontal scroll row of most popular works (vote x log popularity)
- Filmography — tabbed Movies / TV Shows with a sortable table (Popularity / Year / Rating / A-Z), showing year, poster, title, character, rating

Data: `GET /person/{id}` + `GET /person/{id}/combined_credits`

- `src/pages/PersonPage.jsx` — new
- `src/utils/personCredits.js` — new utility for parsing, sorting, scoring

**3. People in search results**

SearchModal previously filtered out `media_type: person`. Now removed — people appear in a "People" section at the top of results with circular avatars. Movies and series render below in a "Movies and Series" section.

- Modified: `src/components/SearchModal.jsx`

**4. Router fix**

`handleSelectResult` was routing `media_type !== "tv"` to the movie page, breaking person navigation. Fixed with explicit person branch. PersonPage added to the lazy page router.

- Modified: `src/App.jsx`

**5. API helpers**

+8 new helpers in `src/utils/api.js`: `fetchPerson`, `fetchPersonCombinedCredits`, `fetchPersonImages`, `fetchPersonMovieCredits`, `fetchPersonTVCredits`, `fetchPopularPeople`, `fetchMovieCredits`, `fetchTVCredits`

---

### Files changed

| File | Change |
|------|--------|
| `src/pages/PersonPage.jsx` | new |
| `src/components/CastRow.jsx` | new |
| `src/components/PersonCard.jsx` | new |
| `src/utils/personCredits.js` | new |
| `src/pages/MoviePage.jsx` | modified |
| `src/pages/TVPage.jsx` | modified |
| `src/components/SearchModal.jsx` | modified |
| `src/App.jsx` | modified |
| `src/utils/api.js` | modified |
| `src/styles/global.css` | modified |

---

### Design notes

- All new CSS reuses existing design tokens — no new colors or fonts introduced
- Profile images use TMDB `h632` size; hero backdrop uses `original`
- Falls back to deterministic colored circles with initials when no profile image
- Closes #65