### PR TITLE
docs: add macOS install and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ sudo pacman -U streambert-*.pacman
 chmod +x Streambert-x64.AppImage && ./Streambert-x64.AppImage
 ```
 
+### macOS (from source)
+
+There are no prebuilt macOS binaries yet. Install and run from source:
+```bash
+git clone https://github.com/truelockmc/streambert.git
+cd streambert
+npm install
+npm run start
+```
+
+> [!TIP]
+> If you're running from inside Cursor or another Electron-based editor, you may need to unset an environment variable first:
+> ```bash
+> unset ELECTRON_RUN_AS_NODE && npm run start
+> ```
+
+To build a `.dmg` yourself:
+```bash
+npm run dist:mac
+```
+
 ### Windows
 
 Download the latest `Streambert Setup *.exe` from the [Releases](https://github.com/truelockmc/streambert/releases/latest) page and run it.
@@ -99,6 +120,10 @@ npm run dist:arch
 or (for an AppImage only)
 ```bash
 npm run dist:appimage
+```
+or (for macOS)
+```bash
+npm run dist:mac
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary
- Add a **macOS (from source)** installation section to the README (between Linux and Windows)
- Include clone/install/run steps, `ELECTRON_RUN_AS_NODE` workaround for Electron-based editors, and how to build a `.dmg`
- Add the missing `npm run dist:mac` command to the Building from Source section

## Context
The README had installation guides for Linux and Windows but nothing for macOS, even though `package.json` already has a `dist:mac` script and full macOS build config. This fills that gap.