### PR TITLE
Auto-switch source when AllManga lacks the requested episode

### DIFF
--- a/src/pages/MoviePage.jsx
+++ b/src/pages/MoviePage.jsx
@@ -21,6 +21,7 @@ import {
   ANIME_DEFAULT_SOURCE,
   NON_ANIME_DEFAULT_SOURCE,
   NEEDS_INTERCEPT,
+  getNextNonAsyncSource,
 } from "../utils/api";
 import {
   PlayIcon,
@@ -43,7 +44,12 @@ import TrailerModal from "../components/TrailerModal";
 import BlockedStatsModal from "../components/BlockedStatsModal";
 import { useBlockedStats } from "../utils/useBlockedStats";
 import MediaCard from "../components/MediaCard";
-import { storage } from "../utils/storage";
+import {
+  storage,
+  getFailoverSource,
+  setFailoverSource,
+  clearFailoverSource,
+} from "../utils/storage";
 import {
   fetchMovieRating,
   isRestricted,
@@ -292,7 +298,25 @@ export default function MoviePage({
 
   // Resolve AllManga movie URL via main-process IPC
   useEffect(() => {
-    if (!playing || !sourceIsAsync(playerSource)) return;
+    if (!playing) return;
+    const epKey = `movie_${item.id}_${dubMode}`;
+
+    // Auto-failover: if a previous attempt taught us AllManga doesn't have
+    // this title, skip straight to the cached fallback source.
+    if (sourceIsAsync(playerSource)) {
+      const cached = getFailoverSource(epKey);
+      if (cached && cached !== playerSource) {
+        setM3u8Url(null);
+        setInterceptedSubs([]);
+        setResolvedPlayerUrl(null);
+        setResolvingUrl(false);
+        setResolveError(null);
+        setPlayerSource(cached);
+        return;
+      }
+    }
+
+    if (!sourceIsAsync(playerSource)) return;
     if (resolvedPlayerUrl || resolvingUrl) return;
     setResolvingUrl(true);
     setResolveError(null);
@@ -309,6 +333,7 @@ export default function MoviePage({
       .then((res) => {
         if (!mounted) return;
         if (res?.ok && res.url) {
+          clearFailoverSource(epKey);
           if (res.isDirectMp4 !== undefined) {
             window.electron
               .setPlayerVideo({
@@ -328,7 +353,19 @@ export default function MoviePage({
             setResolvedPlayerUrl(res.url);
           }
         } else {
-          setResolveError(res?.error || "Movie not found on AllManga");
+          // AllManga doesn't have this title → switch to the next source
+          // automatically and remember the choice for next time.
+          const next = getNextNonAsyncSource(playerSource);
+          if (next) {
+            setFailoverSource(epKey, next);
+            setM3u8Url(null);
+            setInterceptedSubs([]);
+            setResolvedPlayerUrl(null);
+            setResolveError(null);
+            setPlayerSource(next);
+          } else {
+            setResolveError(res?.error || "Movie not found on AllManga");
+          }
         }
       })
       .catch((e) => {
@@ -1014,6 +1051,10 @@ export default function MoviePage({
                     onClick={() => {
                       setShowSourceMenu(false);
                       if (src.id === playerSource) return;
+                      // Manual selection wins over auto-failover for this
+                      // title — otherwise the resolve effect would switch
+                      // back to the cached fallback immediately.
+                      clearFailoverSource(`movie_${item.id}_${dubMode}`);
                       setPlayerSource(src.id);
                       storage.set("playerSource", src.id);
                       setM3u8Url(null);

--- a/src/pages/TVPage.jsx
+++ b/src/pages/TVPage.jsx
@@ -28,6 +28,7 @@ import {
   ANIME_DEFAULT_SOURCE,
   NON_ANIME_DEFAULT_SOURCE,
   NEEDS_INTERCEPT,
+  getNextNonAsyncSource,
 } from "../utils/api";
 import {
   BookmarkIcon,
@@ -49,7 +50,13 @@ import DownloadModal from "../components/DownloadModal";
 import TrailerModal from "../components/TrailerModal";
 import BlockedStatsModal from "../components/BlockedStatsModal";
 import { useBlockedStats } from "../utils/useBlockedStats";
-import { storage, STORAGE_KEYS } from "../utils/storage";
+import {
+  storage,
+  STORAGE_KEYS,
+  getFailoverSource,
+  setFailoverSource,
+  clearFailoverSource,
+} from "../utils/storage";
 import { fetchAniSkipTimings } from "../utils/aniSkip";
 import {
   fetchTVRating,
@@ -644,11 +651,29 @@ export default function TVPage({
 
   // Resolve allmanga episode URL via main-process IPC (GraphQL, no CORS)
   useEffect(() => {
-    if (!playing || !selectedEp || !isAsync) return;
+    if (!playing || !selectedEp) return;
+    const epNum = selectedEp.episode_number;
+    const epKey = `tv_${item.id}_s${selectedSeason}_e${epNum}_${dubMode}`;
+
+    // Auto-failover: if a previous attempt taught us AllManga doesn't have
+    // this episode, skip straight to the cached fallback source.
+    if (isAsync) {
+      const cached = getFailoverSource(epKey);
+      if (cached && cached !== playerSource) {
+        setM3u8Url(null);
+        setInterceptedSubs([]);
+        setResolvedPlayerUrl(null);
+        setResolvingUrl(false);
+        setResolveError(null);
+        setPlayerSource(cached);
+        return;
+      }
+    }
+
+    if (!isAsync) return;
     if (resolvedPlayerUrl || resolvingUrl) return;
     setResolvingUrl(true);
     setResolveError(null);
-    const epNum = selectedEp.episode_number;
     const progressKey = `tv_${item.id}_s${selectedSeason}e${epNum}`;
     const startTime = storage.get("dlTime_" + progressKey) || 0;
     let mounted = true;
@@ -662,6 +687,7 @@ export default function TVPage({
       .then((res) => {
         if (!mounted) return;
         if (res?.ok && res.url) {
+          clearFailoverSource(epKey);
           if (res.isDirectMp4 !== undefined) {
             window.electron
               .setPlayerVideo({
@@ -682,7 +708,19 @@ export default function TVPage({
             setResolvedPlayerUrl(res.url);
           }
         } else {
-          setResolveError(res?.error || "Episode not found on AllManga");
+          // AllManga doesn't have this episode → switch to the next source
+          // automatically and remember the choice for next time.
+          const next = getNextNonAsyncSource(playerSource);
+          if (next) {
+            setFailoverSource(epKey, next);
+            setM3u8Url(null);
+            setInterceptedSubs([]);
+            setResolvedPlayerUrl(null);
+            setResolveError(null);
+            setPlayerSource(next);
+          } else {
+            setResolveError(res?.error || "Episode not found on AllManga");
+          }
         }
       })
       .catch((e) => {
@@ -1803,6 +1841,14 @@ export default function TVPage({
                         onClick={() => {
                           setShowSourceMenu(false);
                           if (src.id === playerSource) return;
+                          // Manual selection wins over auto-failover for the
+                          // current episode — otherwise the resolve effect
+                          // would immediately switch back to the cached one.
+                          if (selectedEp) {
+                            clearFailoverSource(
+                              `tv_${item.id}_s${selectedSeason}_e${selectedEp.episode_number}_${dubMode}`,
+                            );
+                          }
                           setPlayerSource(src.id);
                           storage.set("playerSource", src.id);
                           setM3u8Url(null);

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -177,6 +177,20 @@ export const sourceProgressViaFrames = (sourceId) =>
 export const sourceIsAsync = (sourceId) =>
   PLAYER_SOURCES.find((s) => s.id === sourceId)?.async ?? false;
 
+// Return the next non-async source after `currentId` in PLAYER_SOURCES order,
+// used for auto-failover when the current source can't resolve an episode.
+// Async sources (e.g. AllManga) are skipped because they have the same
+// "missing episode" failure mode and we'd just loop.
+export const getNextNonAsyncSource = (currentId) => {
+  const idx = PLAYER_SOURCES.findIndex((s) => s.id === currentId);
+  if (idx < 0) return null;
+  for (let i = 1; i < PLAYER_SOURCES.length; i++) {
+    const candidate = PLAYER_SOURCES[(idx + i) % PLAYER_SOURCES.length];
+    if (!candidate.async) return candidate.id;
+  }
+  return null;
+};
+
 // Sources that require a transparent webRequest intercept to load properly
 export const NEEDS_INTERCEPT = ["vidsrc", "2embed"];
 

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -80,9 +80,35 @@ export const STORAGE_KEYS = {
   DL_SHOW_UNTRACKED: "dlShowUntracked",
   // Cache for new-episode startup check
   EPISODE_RELEASE_CACHE: "episodeReleaseCache",
+  // Per-episode fallback source when the default (typically AllManga) lacks
+  // the title. Shape: { [epKey]: sourceId }.
+  SOURCE_FAILOVER_CACHE: "sourceFailoverCache",
 };
 
 export const getApiKey = () => storage.get(STORAGE_KEYS.API_KEY);
+
+// ── Source failover cache ────────────────────────────────────────────────────
+// AllManga doesn't always have every episode; rather than nag the user every
+// time, remember the working alternate source per (tmdbId, season, ep, dub)
+// so subsequent visits skip the failed default automatically.
+export const getFailoverSource = (epKey) => {
+  const cache = storage.get(STORAGE_KEYS.SOURCE_FAILOVER_CACHE) || {};
+  return cache[epKey] || null;
+};
+
+export const setFailoverSource = (epKey, sourceId) => {
+  const cache = storage.get(STORAGE_KEYS.SOURCE_FAILOVER_CACHE) || {};
+  cache[epKey] = sourceId;
+  storage.set(STORAGE_KEYS.SOURCE_FAILOVER_CACHE, cache);
+};
+
+export const clearFailoverSource = (epKey) => {
+  const cache = storage.get(STORAGE_KEYS.SOURCE_FAILOVER_CACHE) || {};
+  if (cache[epKey] !== undefined) {
+    delete cache[epKey];
+    storage.set(STORAGE_KEYS.SOURCE_FAILOVER_CACHE, cache);
+  }
+};
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What you'll see today

Pick an anime title in the app and try to play an episode that AllManga doesn't have (e.g. Naruto Shippuden S1E1 currently fails for me). The player overlay says:

> ⚠️ **Episode not found on AllManga**
> No playable link found
> Try a different source, or switch sub/dub.

…and the user has to manually open the source picker and re-pick a non-anime source. Then do it again the next time they visit the same episode, because the choice isn't remembered per title.

## What this PR does

Adds a tiny per-episode failover cache so the app does the manual step for the user, once:

- When `resolveAllManga` returns `{ ok: false }` for an episode, the resolve effect now switches `playerSource` to the next non-async source in `PLAYER_SOURCES` order (Videasy → VidSrc → 2Embed) instead of surfacing the error overlay, and writes the choice into `storage.SOURCE_FAILOVER_CACHE` keyed by `tv_<tmdbId>_s<season>_e<ep>_<dub>` (or `movie_<tmdbId>_<dub>` for movies).
- On subsequent visits to the same episode, the resolve effect checks the cache *before* hitting the IPC and switches sources immediately, so AllManga isn't re-queried for a title we already know it lacks.
- On `resolveAllManga` success the cache entry is cleared, so once AllManga gets the title we naturally fall back to the user's normal preference.
- The source picker dropdown now clears the cache entry for the current title before applying the user's selection, so manual picks can't get clobbered by the failover effect on the next render.

Only the explicit \"no playable link\" branch triggers the switch — network/timeout errors still go through the existing `setResolveError` path so a flaky connection doesn't silently change sources.

## Why this design

I considered two other approaches and rejected them:

- **Probe sources upfront before letting the user click play.** Adds latency on every episode load — even the ~95% of cases where AllManga has the title. The failover-on-error path only pays the cost when the title is actually missing.
- **Heartbeat timer on the iframe sources (Videasy/VidSrc/2Embed) to detect silent failures.** Doable but it's a separate problem (those sources rarely 404 on a title — they usually show their own \"not available\" UI inside the iframe). Kept out of scope to keep this PR small; happy to follow up.

## Files changed

- **`src/utils/storage.js`** — adds `STORAGE_KEYS.SOURCE_FAILOVER_CACHE` and three helpers: `getFailoverSource(epKey)`, `setFailoverSource(epKey, sourceId)`, `clearFailoverSource(epKey)`. The shape is a flat `{ [epKey]: sourceId }` object kept in `localStorage`.
- **`src/utils/api.js`** — adds `getNextNonAsyncSource(currentId)` helper that walks `PLAYER_SOURCES` and returns the next entry whose `async` flag is falsy. Async sources are skipped because they share AllManga's \"missing episode\" failure mode and we'd just loop.
- **`src/pages/TVPage.jsx`** — wires the cache into the existing AllManga resolve `useEffect`: read the cached source up front, write it on `!res.ok`, clear it on success. The source-picker `onClick` also clears the entry for the current episode before applying the user's manual choice.
- **`src/pages/MoviePage.jsx`** — same wiring for the single-resolve movie path with `movie_<tmdbId>_<dub>` as the cache key.

## How to verify

1. Open a series where AllManga is missing an episode (Naruto Shippuden S1E1 is the easy reproducer for me right now).
2. Click that episode and let the resolve attempt finish.
3. **Before this PR:** \"Episode not found on AllManga\" overlay. User must open the source picker manually.
4. **After this PR:** the player switches to Videasy automatically and plays the episode. No overlay flash; just slightly delayed playback start while the next source loads.
5. Navigate away and back to the same episode — second visit goes straight to Videasy without an AllManga IPC roundtrip.
6. Manually pick AllManga from the source dropdown — cache entry for this episode is cleared, so the resolve effect tries AllManga again (and fails again, re-caching to the next source). The failover doesn't fight the user's manual override on the same click.
