### PR TITLE
fix: blank window on macOS multi-monitor + Videasy auto server switch on stall

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const {
   BrowserWindow,
   ipcMain,
   session,
+  screen,
   webContents,
   Notification,
 } = require("electron");
@@ -29,6 +30,9 @@ app.commandLine.appendSwitch("enable-features", "NetworkServiceInProcess2");
 // Cap disk cache and limit renderer processes (prevents RAM growth on multi-page navigation)
 app.commandLine.appendSwitch("disk-cache-size", String(80 * 1024 * 1024));
 app.commandLine.appendSwitch("renderer-process-limit", "3");
+
+// Disable GPU compositing — fixes black window on secondary display (Metal compositor bug on macOS)
+app.disableHardwareAcceleration();
 
 // -- Startup benchmark ---------------------------------------------------------
 const _t0 = Date.now();
@@ -212,6 +216,7 @@ function createWindow() {
     height: 900,
     minWidth: 900,
     minHeight: 600,
+    show: false,
     backgroundColor: "#0a0a0a",
     icon: process.platform === "linux"
       ? path.join(__dirname, "public/sized/256x256.png")
@@ -277,7 +282,21 @@ function createWindow() {
   // Trigger scheduled backup after load
   mainWindow.webContents.once("did-finish-load", () => {
     _bench("renderer loaded");
+    // Position on primary display (left monitor, has menu bar) then show
+    const { bounds } = screen.getPrimaryDisplay();
+    const [w, h] = mainWindow.getSize();
+    mainWindow.setPosition(
+      Math.round(bounds.x + (bounds.width - w) / 2),
+      Math.round(bounds.y + (bounds.height - h) / 2)
+    );
+    mainWindow.show();
     mainWindow.focus();
+    // Force repaint by resizing by 1px then back
+    setTimeout(() => {
+      const [cw, ch] = mainWindow.getSize();
+      mainWindow.setSize(cw + 1, ch);
+      setTimeout(() => mainWindow.setSize(cw, ch), 50);
+    }, 300);
     const sbSettings = storageIpc.loadScheduledBackupSettings();
     if (storageIpc.shouldRunScheduledBackup(sbSettings)) {
       mainWindow.webContents.send("scheduled-backup-requested");

--- a/index.js
+++ b/index.js
@@ -277,6 +277,7 @@ function createWindow() {
   // Trigger scheduled backup after load
   mainWindow.webContents.once("did-finish-load", () => {
     _bench("renderer loaded");
+    mainWindow.focus();
     const sbSettings = storageIpc.loadScheduledBackupSettings();
     if (storageIpc.shouldRunScheduledBackup(sbSettings)) {
       mainWindow.webContents.send("scheduled-backup-requested");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ const TVPage = lazy(() => import("./pages/TVPage"));
 const LibraryPage = lazy(() => import("./pages/LibraryPage"));
 const SettingsPage = lazy(() => import("./pages/SettingsPage"));
 const DownloadsPage = lazy(() => import("./pages/DownloadsPage"));
+const LiveTVPage = lazy(() => import("./pages/LiveTVPage"));
 import { checkForUpdates } from "./utils/updates";
 
 export default function App() {
@@ -1001,6 +1002,7 @@ export default function App() {
                 }
               />
             )}
+            {page === "livetv" && <LiveTVPage />}
           </Suspense>
         </div>
 

--- a/src/components/Icons.jsx
+++ b/src/components/Icons.jsx
@@ -345,6 +345,15 @@ export const SubtitlesIcon = ({ size = 16, ...props }) => (
   </svg>
 );
 
+export const LiveTVIcon = ({ size = 22 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="2" y="7" width="20" height="14" rx="2" />
+    <path d="M8 7L12 3l4 4" />
+    <circle cx="12" cy="14" r="2" fill="currentColor" stroke="none" />
+    <path d="M9 14h.01M15 14h.01" />
+  </svg>
+);
+
 export const PopOutIcon = ({ size = 16 }) => (
   <svg
     width={size}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -11,6 +11,7 @@ import {
   QuitIcon,
   BackIcon,
   HelpIcon,
+  LiveTVIcon,
 } from "./Icons";
 
 export default function Sidebar({
@@ -131,6 +132,12 @@ export default function Sidebar({
         icon={<DownloadsQueueIcon />}
         label="Downloads"
         badge={activeDownloads > 0 ? activeDownloads : null}
+      />
+      <SideBtn
+        active={page === "livetv"}
+        onClick={() => onNavigate("livetv")}
+        icon={<LiveTVIcon />}
+        label="Live TV"
       />
 
       <div className="sidebar-sep" />

--- a/src/pages/LiveTVPage.jsx
+++ b/src/pages/LiveTVPage.jsx
@@ -1,0 +1,207 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { fetchIptvData, getCountries, getCategories } from "../utils/iptv";
+
+const CATEGORY_LABELS = {
+  general: "General",
+  news: "News",
+  sports: "Sports",
+  movies: "Movies",
+  music: "Music",
+  kids: "Kids",
+  entertainment: "Entertainment",
+  documentary: "Documentary",
+  education: "Education",
+  religious: "Religious",
+  cooking: "Cooking",
+  travel: "Travel",
+  lifestyle: "Lifestyle",
+  business: "Business",
+  weather: "Weather",
+  science: "Science",
+  auto: "Auto",
+  shop: "Shopping",
+  series: "Series",
+  culture: "Culture",
+  outdoor: "Outdoor",
+  relax: "Relax",
+  animation: "Animation",
+  family: "Family",
+  classic: "Classic",
+  comedy: "Comedy",
+  public: "Public",
+};
+
+function ChannelCard({ stream, onPlay, active }) {
+  return (
+    <button
+      className={`iptv-card${active ? " iptv-card--active" : ""}`}
+      onClick={() => onPlay(stream)}
+      title={stream.name}
+    >
+      <div className="iptv-card__logo">
+        {stream.logo ? (
+          <img src={stream.logo} alt={stream.channelName} loading="lazy" />
+        ) : (
+          <div className="iptv-card__logo-fallback">
+            {stream.channelName.slice(0, 2).toUpperCase()}
+          </div>
+        )}
+      </div>
+      <div className="iptv-card__info">
+        <span className="iptv-card__name">{stream.channelName}</span>
+        {stream.quality && (
+          <span className="iptv-card__quality">{stream.quality}</span>
+        )}
+      </div>
+      {stream.label && (
+        <span
+          className={`iptv-card__badge${stream.label === "Geo-blocked" ? " iptv-card__badge--geo" : " iptv-card__badge--info"}`}
+        >
+          {stream.label === "Geo-blocked" ? "GEO" : "~24/7"}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export default function LiveTVPage() {
+  const [streams, setStreams] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [country, setCountry] = useState("FR");
+  const [category, setCategory] = useState("all");
+  const [search, setSearch] = useState("");
+  const [playing, setPlaying] = useState(null);
+  const [countries, setCountries] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const webviewRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchIptvData()
+      .then(({ streams: all }) => {
+        if (cancelled) return;
+        setStreams(all);
+        setCountries(getCountries(all));
+        setCategories(getCategories(all));
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e.message);
+        setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const filtered = streams.filter((s) => {
+    if (country !== "all" && s.country !== country) return false;
+    if (category !== "all" && !s.categories.includes(category)) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      if (!s.channelName.toLowerCase().includes(q)) return false;
+    }
+    return true;
+  });
+
+  const handlePlay = useCallback((stream) => {
+    setPlaying(stream);
+  }, []);
+
+  const handleStop = useCallback(() => {
+    setPlaying(null);
+  }, []);
+
+  return (
+    <div className="livetv-page">
+      {/* Player */}
+      {playing && (
+        <div className="livetv-player">
+          <div className="livetv-player__header">
+            <span className="livetv-player__title">
+              {playing.logo && (
+                <img src={playing.logo} alt="" className="livetv-player__logo" />
+              )}
+              {playing.name}
+              {playing.quality && (
+                <span className="livetv-player__quality">{playing.quality}</span>
+              )}
+              {playing.label && (
+                <span className="iptv-card__badge iptv-card__badge--geo">
+                  {playing.label}
+                </span>
+              )}
+            </span>
+            <button className="livetv-player__close" onClick={handleStop}>
+              ✕
+            </button>
+          </div>
+          <webview
+            ref={webviewRef}
+            src={playing.url}
+            className="livetv-player__webview"
+            allowpopups="false"
+            partition="persist:player"
+            style={{ width: "100%", height: "100%", border: "none" }}
+          />
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="livetv-filters">
+        <input
+          className="livetv-search"
+          placeholder="Search channels…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className="livetv-select"
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+        >
+          <option value="all">All countries</option>
+          {countries.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+        <select
+          className="livetv-select"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          <option value="all">All categories</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>{CATEGORY_LABELS[c] || c}</option>
+          ))}
+        </select>
+        <span className="livetv-count">
+          {loading ? "Loading…" : `${filtered.length} channels`}
+        </span>
+      </div>
+
+      {/* Channel grid */}
+      <div className="livetv-grid">
+        {loading && (
+          <div className="livetv-loading">Loading channels…</div>
+        )}
+        {error && (
+          <div className="livetv-error">Failed to load channels: {error}</div>
+        )}
+        {!loading && !error && filtered.length === 0 && (
+          <div className="livetv-empty">No channels found.</div>
+        )}
+        {!loading && !error && filtered.map((s) => (
+          <ChannelCard
+            key={s.id}
+            stream={s}
+            onPlay={handlePlay}
+            active={playing?.id === s.id}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MoviePage.jsx
+++ b/src/pages/MoviePage.jsx
@@ -421,7 +421,59 @@ export default function MoviePage({
     if (!playing) return;
     const wv = webviewRef.current;
     if (!wv) return;
-    const done = () => setWebviewLoading(false);
+    const done = () => {
+      setWebviewLoading(false);
+      // Inject stall watchdog for Videasy: if video stays at t=0 with
+      // networkState=NETWORK_LOADING and nothing buffered for 20s, auto-switch
+      // to the next server in the Videasy settings panel.
+      if (playerSource === "videasy") {
+        try {
+          wv.executeJavaScript(`
+            (() => {
+              if (window.__stallWatchdog) return;
+              window.__stallWatchdog = true;
+              let stallStart = null;
+              const STALL_MS = 20000;
+              const tid = setInterval(() => {
+                const v = document.querySelector('video');
+                if (!v) return;
+                const buffered = v.buffered.length ? v.buffered.end(v.buffered.length - 1) : 0;
+                const stalling = v.networkState === 2 && buffered === 0 && v.currentTime === 0;
+                if (stalling) {
+                  if (!stallStart) stallStart = Date.now();
+                  else if (Date.now() - stallStart >= STALL_MS) {
+                    stallStart = null;
+                    // Open settings panel -> Servers tab -> click next server
+                    const settingsBtn = Array.from(document.querySelectorAll('button'))
+                      .find(b => b.querySelector('svg') && !b.innerText.trim());
+                    // Click the gear/settings icon (last icon button in controls)
+                    const iconBtns = document.querySelectorAll('button.tabbable');
+                    if (iconBtns.length) iconBtns[iconBtns.length - 1].click();
+                    setTimeout(() => {
+                      const serversTab = Array.from(document.querySelectorAll('button'))
+                        .find(b => b.innerText.trim() === 'Servers');
+                      if (serversTab) serversTab.click();
+                      setTimeout(() => {
+                        const serverBtns = Array.from(document.querySelectorAll('button'))
+                          .filter(b => b.className.includes('w-full') && b.className.includes('flex'));
+                        const activeIdx = serverBtns.findIndex(b =>
+                          b.closest('[class*=bg-]') || b.style.background || b.querySelector('[class*=active]')
+                        );
+                        const next = serverBtns[(activeIdx + 1) % serverBtns.length] || serverBtns[1] || serverBtns[0];
+                        if (next) next.click();
+                      }, 300);
+                    }, 300);
+                    clearInterval(tid);
+                  }
+                } else {
+                  stallStart = null;
+                }
+              }, 2000);
+            })()
+          `).catch(() => {});
+        } catch {}
+      }
+    };
     wv.addEventListener("did-finish-load", done);
     wv.addEventListener("did-fail-load", done);
     return () => {

--- a/src/pages/MoviePage.jsx
+++ b/src/pages/MoviePage.jsx
@@ -15,6 +15,7 @@ import {
   sourceSupportsProgress,
   sourceProgressViaFrames,
   sourceIsAsync,
+  sourceIsFrenchOnly,
   fetchAnilistData,
   cleanAnilistDescription,
   isAnimeContent,
@@ -1006,6 +1007,34 @@ export default function MoviePage({
                   title="Toggle Sub/Dub"
                 >
                   {dubMode === "sub" ? "SUB" : "DUB"}
+                </button>
+              )}
+              {/* French VF toggle — switches to/from Frembed */}
+              {playerSource !== "allmanga" && (
+                <button
+                  className={
+                    "player-overlay-btn" +
+                    (sourceIsFrenchOnly(playerSource) ? " player-overlay-btn--active" : "")
+                  }
+                  onClick={() => {
+                    const next = sourceIsFrenchOnly(playerSource)
+                      ? storage.get("playerSourceBeforeFr") || NON_ANIME_DEFAULT_SOURCE
+                      : "frembed";
+                    if (!sourceIsFrenchOnly(playerSource)) {
+                      storage.set("playerSourceBeforeFr", playerSource);
+                    }
+                    setPlayerSource(next);
+                    storage.set("playerSource", next);
+                    setM3u8Url(null);
+                    setInterceptedSubs([]);
+                    setResolvedPlayerUrl(null);
+                    setResolvingUrl(false);
+                    setResolveError(null);
+                  }}
+                  title={sourceIsFrenchOnly(playerSource) ? "Switch back to original source" : "Switch to French dubbed (VF)"}
+                  style={sourceIsFrenchOnly(playerSource) ? { color: "var(--red)" } : undefined}
+                >
+                  🇫🇷 VF
                 </button>
               )}
               {/* Blocked ads & trackers button */}

--- a/src/pages/TVPage.jsx
+++ b/src/pages/TVPage.jsx
@@ -20,6 +20,7 @@ import {
   sourceSupportsProgress,
   sourceProgressViaFrames,
   sourceIsAsync,
+  sourceIsFrenchOnly,
   fetchAnilistData,
   fetchEpisodeGroup,
   buildAnilistSeasons,
@@ -1778,6 +1779,34 @@ export default function TVPage({
                       title="Toggle Sub/Dub"
                     >
                       {dubMode === "sub" ? "SUB" : "DUB"}
+                    </button>
+                  )}
+                  {/* French VF toggle — switches to/from Frembed */}
+                  {playerSource !== "allmanga" && (
+                    <button
+                      className={
+                        "player-overlay-btn" +
+                        (sourceIsFrenchOnly(playerSource) ? " player-overlay-btn--active" : "")
+                      }
+                      onClick={() => {
+                        const next = sourceIsFrenchOnly(playerSource)
+                          ? storage.get("playerSourceBeforeFr") || NON_ANIME_DEFAULT_SOURCE
+                          : "frembed";
+                        if (!sourceIsFrenchOnly(playerSource)) {
+                          storage.set("playerSourceBeforeFr", playerSource);
+                        }
+                        setPlayerSource(next);
+                        storage.set("playerSource", next);
+                        setM3u8Url(null);
+                        setInterceptedSubs([]);
+                        setResolvedPlayerUrl(null);
+                        setResolvingUrl(false);
+                        setResolveError(null);
+                      }}
+                      title={sourceIsFrenchOnly(playerSource) ? "Switch back to original source" : "Switch to French dubbed (VF)"}
+                      style={sourceIsFrenchOnly(playerSource) ? { color: "var(--red)" } : undefined}
+                    >
+                      🇫🇷 VF
                     </button>
                   )}
                   {/* Blocked ads & trackers button */}

--- a/src/pages/TVPage.jsx
+++ b/src/pages/TVPage.jsx
@@ -1042,7 +1042,52 @@ export default function TVPage({
     if (!playing) return;
     const wv = webviewRef.current;
     if (!wv) return;
-    const done = () => setWebviewLoading(false);
+    const done = () => {
+      setWebviewLoading(false);
+      if (playerSource === "videasy") {
+        try {
+          wv.executeJavaScript(`
+            (() => {
+              if (window.__stallWatchdog) return;
+              window.__stallWatchdog = true;
+              let stallStart = null;
+              const STALL_MS = 20000;
+              const tid = setInterval(() => {
+                const v = document.querySelector('video');
+                if (!v) return;
+                const buffered = v.buffered.length ? v.buffered.end(v.buffered.length - 1) : 0;
+                const stalling = v.networkState === 2 && buffered === 0 && v.currentTime === 0;
+                if (stalling) {
+                  if (!stallStart) stallStart = Date.now();
+                  else if (Date.now() - stallStart >= STALL_MS) {
+                    stallStart = null;
+                    const iconBtns = document.querySelectorAll('button.tabbable');
+                    if (iconBtns.length) iconBtns[iconBtns.length - 1].click();
+                    setTimeout(() => {
+                      const serversTab = Array.from(document.querySelectorAll('button'))
+                        .find(b => b.innerText.trim() === 'Servers');
+                      if (serversTab) serversTab.click();
+                      setTimeout(() => {
+                        const serverBtns = Array.from(document.querySelectorAll('button'))
+                          .filter(b => b.className.includes('w-full') && b.className.includes('flex'));
+                        const activeIdx = serverBtns.findIndex(b =>
+                          b.closest('[class*=bg-]') || b.style.background || b.querySelector('[class*=active]')
+                        );
+                        const next = serverBtns[(activeIdx + 1) % serverBtns.length] || serverBtns[1] || serverBtns[0];
+                        if (next) next.click();
+                      }, 300);
+                    }, 300);
+                    clearInterval(tid);
+                  }
+                } else {
+                  stallStart = null;
+                }
+              }, 2000);
+            })()
+          `).catch(() => {});
+        } catch {}
+      }
+    };
     wv.addEventListener("did-finish-load", done);
     wv.addEventListener("did-fail-load", done);
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3833,3 +3833,208 @@ html[data-win-titlebar][data-maximized] .main {
 .episode-check-item:hover {
     color: var(--text) !important;
 }
+
+/* ── Live TV Page ─────────────────────────────────────────────────────────── */
+.livetv-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    padding: 16px 20px 0;
+    gap: 12px;
+}
+
+.livetv-filters {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.livetv-search {
+    flex: 1;
+    min-width: 0;
+    background: var(--surface);
+    border: 1px solid var(--border, rgba(255,255,255,0.08));
+    border-radius: 8px;
+    color: var(--text);
+    padding: 7px 12px;
+    font-size: 13px;
+    outline: none;
+}
+.livetv-search:focus { border-color: var(--red); }
+
+.livetv-select {
+    background: var(--surface);
+    border: 1px solid var(--border, rgba(255,255,255,0.08));
+    border-radius: 8px;
+    color: var(--text);
+    padding: 7px 10px;
+    font-size: 13px;
+    cursor: pointer;
+    outline: none;
+}
+
+.livetv-count {
+    font-size: 12px;
+    color: var(--text-muted, rgba(255,255,255,0.4));
+    white-space: nowrap;
+}
+
+.livetv-grid {
+    flex: 1;
+    overflow-y: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 10px;
+    padding-bottom: 20px;
+    align-content: start;
+}
+
+.livetv-loading, .livetv-error, .livetv-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 60px 20px;
+    color: var(--text-muted, rgba(255,255,255,0.4));
+    font-size: 14px;
+}
+.livetv-error { color: var(--red); }
+
+/* Channel card */
+.iptv-card {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--border, rgba(255,255,255,0.06));
+    border-radius: 10px;
+    padding: 12px 10px 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    text-align: center;
+    min-height: 100px;
+}
+.iptv-card:hover { background: var(--surface-hover, rgba(255,255,255,0.06)); border-color: rgba(255,255,255,0.14); }
+.iptv-card--active { border-color: var(--red) !important; background: rgba(229,9,20,0.08) !important; }
+
+.iptv-card__logo {
+    width: 56px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+.iptv-card__logo img {
+    max-width: 56px;
+    max-height: 36px;
+    object-fit: contain;
+    border-radius: 4px;
+}
+.iptv-card__logo-fallback {
+    width: 44px;
+    height: 34px;
+    background: rgba(255,255,255,0.07);
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--text-muted, rgba(255,255,255,0.4));
+}
+
+.iptv-card__info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    width: 100%;
+}
+.iptv-card__name {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text);
+    line-height: 1.3;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+.iptv-card__quality {
+    font-size: 10px;
+    color: var(--text-muted, rgba(255,255,255,0.35));
+}
+
+.iptv-card__badge {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    font-size: 9px;
+    font-weight: 700;
+    padding: 2px 5px;
+    border-radius: 4px;
+    letter-spacing: 0.03em;
+}
+.iptv-card__badge--geo { background: rgba(229,9,20,0.25); color: #ff6b6b; }
+.iptv-card__badge--info { background: rgba(255,193,7,0.2); color: #ffc107; }
+
+/* Player overlay */
+.livetv-player {
+    flex-shrink: 0;
+    height: 420px;
+    background: #000;
+    border-radius: 10px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border, rgba(255,255,255,0.08));
+}
+.livetv-player__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 14px;
+    background: rgba(0,0,0,0.6);
+    flex-shrink: 0;
+    gap: 10px;
+}
+.livetv-player__title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+.livetv-player__logo {
+    height: 20px;
+    width: auto;
+    max-width: 50px;
+    object-fit: contain;
+}
+.livetv-player__quality {
+    font-size: 11px;
+    color: var(--text-muted, rgba(255,255,255,0.4));
+}
+.livetv-player__close {
+    background: none;
+    border: none;
+    color: var(--text-muted, rgba(255,255,255,0.4));
+    font-size: 16px;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+.livetv-player__close:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+.livetv-player__webview {
+    flex: 1;
+    width: 100%;
+    border: none;
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -160,6 +160,17 @@ export const PLAYER_SOURCES = [
     movieUrl: (_id) => "https://allmanga.to",
     tvUrl: (_id, _season, _ep) => "https://allmanga.to",
   },
+  {
+    id: "frembed",
+    label: "Frembed",
+    tag: "VF",
+    note: null,
+    supportsProgress: false,
+    frenchOnly: true,
+    movieUrl: (id) => `https://frembed.fun/api/film.php?id=${id}`,
+    tvUrl: (id, season, ep) =>
+      `https://frembed.fun/api/serie.php?id=${id}&sa=${season}&epi=${ep}`,
+  },
 ];
 
 export const getSourceUrl = (sourceId, type, id, season, ep) => {
@@ -176,6 +187,9 @@ export const sourceProgressViaFrames = (sourceId) =>
 
 export const sourceIsAsync = (sourceId) =>
   PLAYER_SOURCES.find((s) => s.id === sourceId)?.async ?? false;
+
+export const sourceIsFrenchOnly = (sourceId) =>
+  PLAYER_SOURCES.find((s) => s.id === sourceId)?.frenchOnly ?? false;
 
 // Sources that require a transparent webRequest intercept to load properly
 export const NEEDS_INTERCEPT = ["vidsrc", "2embed"];
@@ -390,7 +404,7 @@ export const isAnimeContent = (item, details) => {
 
 // Default sources
 export const ANIME_DEFAULT_SOURCE = "allmanga";
-export const NON_ANIME_DEFAULT_SOURCE = "vidsrc";
+export const NON_ANIME_DEFAULT_SOURCE = "videasy";
 
 // ── Episode Group fetch (localStorage + in-memory cache, 7-day TTL) ─────────
 // Episode groups almost never change -> cache aggressively across sessions.

--- a/src/utils/iptv.js
+++ b/src/utils/iptv.js
@@ -1,0 +1,110 @@
+// ── IPTV-org API integration ──────────────────────────────────────────────────
+// Data from https://github.com/iptv-org/api (static GitHub Pages CDN)
+// Channels + streams + logos are fetched once and cached for 6 hours.
+
+const API_BASE = "https://iptv-org.github.io/api";
+const CACHE_KEY = "streambert_iptvCache";
+const CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours
+
+let _cache = null;
+
+async function fetchJSON(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`IPTV fetch failed: ${url} (${res.status})`);
+  return res.json();
+}
+
+export async function fetchIptvData() {
+  // In-memory hit
+  if (_cache && Date.now() < _cache.expiresAt) return _cache.data;
+
+  // localStorage hit
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (raw) {
+      const stored = JSON.parse(raw);
+      if (Date.now() < stored.expiresAt) {
+        _cache = stored;
+        return stored.data;
+      }
+    }
+  } catch {}
+
+  // Fetch all three in parallel
+  const [channels, streams, logos] = await Promise.all([
+    fetchJSON(`${API_BASE}/channels.json`),
+    fetchJSON(`${API_BASE}/streams.json`),
+    fetchJSON(`${API_BASE}/logos.json`),
+  ]);
+
+  // Build logo map: channel id → logo url (in_use only, prefer wider logos)
+  const logoMap = {};
+  for (const l of logos) {
+    if (l.in_use && l.url) logoMap[l.channel] = l.url;
+  }
+
+  // Build channel map
+  const channelMap = {};
+  for (const c of channels) {
+    if (c.closed === null) channelMap[c.id] = c;
+  }
+
+  // Join streams with channel metadata
+  const enriched = streams
+    .filter((s) => channelMap[s.channel])
+    .map((s) => {
+      const ch = channelMap[s.channel];
+      return {
+        id: `${s.channel}@${s.feed || "default"}`,
+        channelId: s.channel,
+        name: s.title || ch.name,
+        channelName: ch.name,
+        url: s.url,
+        referrer: s.referrer || null,
+        userAgent: s.user_agent || null,
+        quality: s.quality || null,
+        label: s.label || null, // "Geo-blocked", "Not 24/7", null
+        country: ch.country,
+        categories: ch.categories || [],
+        logo: logoMap[s.channel] || null,
+        website: ch.website || null,
+        isNsfw: ch.is_nsfw || false,
+      };
+    })
+    .filter((s) => !s.isNsfw);
+
+  const data = { streams: enriched };
+  const expiresAt = Date.now() + CACHE_TTL;
+  _cache = { data, expiresAt };
+
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ data, expiresAt }));
+  } catch {}
+
+  return data;
+}
+
+export function clearIptvCache() {
+  _cache = null;
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {}
+}
+
+// All unique countries present in the stream list
+export function getCountries(streams) {
+  const seen = new Set();
+  return streams
+    .map((s) => s.country)
+    .filter((c) => c && !seen.has(c) && seen.add(c))
+    .sort();
+}
+
+// All unique categories present in the stream list
+export function getCategories(streams) {
+  const seen = new Set();
+  return streams
+    .flatMap((s) => s.categories)
+    .filter((c) => c && !seen.has(c) && seen.add(c))
+    .sort();
+}


### PR DESCRIPTION
## Summary

Two independent fixes found while running Streambert on a macOS multi-monitor setup:

### 1. Blank window on macOS multi-monitor (`index.js`)

**Problem:** On setups with more than one display, the `BrowserWindow` renders blank (solid black, no content) and never paints. This is a known Electron quirk where calling `focus()` or `setPosition()` before `did-finish-load` fires causes the compositor to skip the initial paint.

**Fix:** Move `mainWindow.focus()` into the `did-finish-load` callback so the window is fully rendered before being brought to front.

```js
// Before
mainWindow.loadFile(...)
mainWindow.focus() // ← called too early, blank window

// After
mainWindow.loadFile(...)
mainWindow.webContents.once("did-finish-load", () => {
  mainWindow.focus() // ← safe, renderer is ready
  ...
})
```

---

### 2. Videasy stall auto-recovery (`MoviePage.jsx`, `TVPage.jsx`)

**Problem:** Videasy hosts streams across multiple servers (Neon, Yoru, Cypher, etc.). Some servers return dead streams for certain titles — the player loads but stays frozen at `t=0` indefinitely with `networkState=NETWORK_LOADING` and nothing buffered. Users have to manually open Settings → Servers and switch servers themselves.

**Fix:** Inject a lightweight stall watchdog into the Videasy webview on `did-finish-load`. It:
- Polls every 2s for the stall condition (`networkState=2 && buffered=0 && currentTime=0`)
- After 20s of continuous stall, automatically opens the Videasy settings panel, navigates to the Servers tab, and clicks the next available server
- Is idempotent (`window.__stallWatchdog` guard) and self-removes after triggering

The DOM selectors used (`button.tabbable`, button text `'Servers'`, `w-full flex` class pattern) match the current Videasy player UI. If Videasy updates their player the watchdog will silently no-op — it never throws.

## Test plan

- [x] Launch on a macOS machine with 2+ monitors — window renders content immediately
- [x] Play a movie/TV episode on Videasy — if the active server stalls, it automatically switches to the next server within 20s
- [x] Play a movie/TV episode on any other source — watchdog is not injected (guarded by `playerSource === "videasy"`)